### PR TITLE
Add schema to cursors

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -13,7 +13,7 @@ function Cursor() {
   this.schema = null;
 }
 
-Cursor.prototype.metadata = function(
+Cursor.prototype.definition = function(
   // Attach schema
   schema // object, schema
   // Return: previous instance
@@ -103,7 +103,7 @@ Cursor.prototype.select = function(
 ) {
   const cursor = new Cursor.MemoryCursor();
   cursor.parent = this;
-  if (this.schema) cursor.metadata(this.schema);
+  if (this.schema) cursor.definition(this.schema);
   cursor.jsql.push({ op: 'select', query });
   return cursor;
 };

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -10,7 +10,17 @@ function Cursor() {
   this.dataset = [];
   this.children = [];
   this.jsql = [];
+  this.schema = null;
 }
+
+Cursor.prototype.metadata = function(
+  // Attach schema
+  schema // object, schema
+  // Return: previous instance
+) {
+  this.schema = schema;
+  return this;
+};
 
 Cursor.prototype.copy = function(
   // Copy references to new dataset
@@ -93,6 +103,7 @@ Cursor.prototype.select = function(
 ) {
   const cursor = new Cursor.MemoryCursor();
   cursor.parent = this;
+  if (this.schema) cursor.metadata(this.schema);
   cursor.jsql.push({ op: 'select', query });
   return cursor;
 };
@@ -289,11 +300,11 @@ Cursor.prototype.complement = function(
 
 Cursor.prototype.fetch = function(
   // Get results after allying consolidated jsql
-  done // callback function(err, dataset)
+  done // callback function(err, dataset, cursor)
   // Return: previous instance from chain
 ) {
   done = common.once(done);
-  done(new Error(core.NOT_IMPLEMENTED));
+  done(new Error(core.NOT_IMPLEMENTED), null, this);
   return this;
 };
 

--- a/lib/memory.cursor.js
+++ b/lib/memory.cursor.js
@@ -52,7 +52,7 @@ MemoryCursor.prototype.fetch = function(done) {
       }
     });
     this.jsql.length = 0;
-    done(null, dataset);
+    done(null, dataset, this);
   };
 
   if (this.parent) {

--- a/lib/mongodb.cursor.js
+++ b/lib/mongodb.cursor.js
@@ -56,7 +56,7 @@ MongodbCursor.prototype.fetch = function(done) {
   done = common.once(done);
   this.cursor.toArray((err, dataset) => {
     if (err) {
-      done(err);
+      done(err, null, this);
       return;
     }
     this.jsql.forEach(operation => {
@@ -66,7 +66,7 @@ MongodbCursor.prototype.fetch = function(done) {
       }
     });
     this.jsql.length = 0;
-    done(null, dataset);
+    done(null, dataset, this);
     return this;
   });
   return this;

--- a/test/memory.js
+++ b/test/memory.js
@@ -85,11 +85,12 @@ api.metatests.test('cursor schema', (test) => {
   metaschema.load('schemas/system', (err, schemas) => {
     if (err) throw err;
     metaschema.build(schemas);
-    const { definition } = metaschema.categories.get('Language');
-    const mcLanguages = new gs.MemoryCursor(languages).metadata(definition);
+    const schema = metaschema.categories.get('Language').definition;
+    const mcLanguages = new gs.MemoryCursor(languages).definition(schema);
     mcLanguages.select({ Locale: '> en' })
       .order('Name')
       .fetch((err, data, cursor) => {
+        console.dir({ err, data, cursor }, { depth: null });
         test.strictSame(data.length, 2);
         test.strictSame(Object.keys(cursor.schema).length, 2);
         test.end();

--- a/test/memory.js
+++ b/test/memory.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const gs = require('..');
+const metaschema = require('metaschema');
 
 const ds1 = [ { id: 1, name: 'qwerty' }, { id: 2 } ];
 const ds2 = [ { id: 2 }, { id: 3 } ];
@@ -73,4 +74,25 @@ api.metatests.test('cursor select', (test) => {
       test.strictSame(data, expected, 'Wrong data');
       test.end('select test done');
     });
+});
+
+api.metatests.test('cursor schema', (test) => {
+  const languages = [
+    { Name: 'English', Locale: 'en' },
+    { Name: 'Ukrainian', Locale: 'uk' },
+    { Name: 'Russian', Locale: 'ru' },
+  ];
+  metaschema.load('schemas/system', (err, schemas) => {
+    if (err) throw err;
+    metaschema.build(schemas);
+    const { definition } = metaschema.categories.get('Language');
+    const mcLanguages = new gs.MemoryCursor(languages).metadata(definition);
+    mcLanguages.select({ Locale: '> en' })
+      .order('Name')
+      .fetch((err, data, cursor) => {
+        test.strictSame(data.length, 2);
+        test.strictSame(Object.keys(cursor.schema).length, 2);
+        test.end();
+      });
+  });
 });


### PR DESCRIPTION
Here is an example of fetch callback arguments: err, data, cursor
```js
{ err: null,
  data:
   [ { Name: 'Russian', Locale: 'ru' },
     { Name: 'Ukrainian', Locale: 'uk' } ],
  cursor:
   MemoryCursor {
     parent:
      MemoryCursor {
        parent: null,
        provider: null,
        dataset:
         [ { Name: 'English', Locale: 'en' },
           { Name: 'Ukrainian', Locale: 'uk' },
           { Name: 'Russian', Locale: 'ru' } ],
        children: [],
        jsql: [],
        schema:
         Dictionary {
           Name:
            { domain: 'Nomen', lookup: true, required: true, unique: true },
           Locale: { domain: 'Nomen', required: true, unique: true } },
        indices: {} },
     provider: null,
     dataset: undefined,
     children: [],
     jsql: [],
     schema:
      Dictionary {
        Name:
         { domain: 'Nomen', lookup: true, required: true, unique: true },
        Locale: { domain: 'Nomen', required: true, unique: true } },
     indices: {} } }
```