### PR TITLE
Refactor cursor add pg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - 10
 sudo: false
 services:
-  - mongodb
+  - postgresql
+before_script:
+  - psql -c 'create database test_globalstorage_database;' -U postgres
 script:
   - npm test

--- a/gs.js
+++ b/gs.js
@@ -7,7 +7,7 @@ const submodules = [
   'provider', 'cursor',
   'memory.provider', 'memory.cursor',
   'remote.provider', 'remote.cursor',
-  'fs.provider', 'fs.cursor',
+  'fs.provider', 'fs.cursor', 'pg.cursor',
 ];
 
 let gs = null;

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const NOT_IMPLEMENTED = 'Not implemented';
+const NOT_SUPPORTED = 'Not supported';
 
 module.exports = {
   NOT_IMPLEMENTED,
+  NOT_SUPPORTED,
 };

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -79,17 +79,11 @@ class Cursor {
 
   projection(
     // Declarative lazy projection
-    mapping // projection metadata array of field names
+    metadata // projection metadata array of field names
     // or structure: [ { toKey: [ fromKey, functions... ] } ]
     // Return: previous instance from chain
   ) {
-    if (Array.isArray(mapping)) {
-      // Array of field names
-      this.jsql.push({ op: 'projection', fields: mapping });
-    } else {
-      // Object describing mappings
-      this.jsql.push({ op: 'projection', metadata: mapping });
-    }
+    this.jsql.push({ op: 'projection', metadata });
     return this;
   }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -256,10 +256,10 @@ class Cursor {
 
   limit(
     // Get first n records from dataset
-    n // Number
+    count // Number
     // Return: previous instance from chain
   ) {
-    this.jsql.push({ op: 'limit', count: n });
+    this.jsql.push({ op: 'limit', count });
     return this;
   }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -263,6 +263,15 @@ class Cursor {
     return this;
   }
 
+  offset(
+    // Offset into the dataset
+    offset // Number
+    // Return: previous instance from chain
+  ) {
+    this.jsql.push({ op: 'offset', offset });
+    return this;
+  }
+
   union(
     // Calculate union and put results to this Cursor instance
     cursor // Cursor instance

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -19,12 +19,13 @@ class Cursor {
     this.parents = options && options.parents ? options.parents.slice() : [];
   }
 
-  definition(
-    // Attach schema
-    schema // object, schema
-    // Return: previous instance
-  ) {
+  // Attach schema
+  //   schema, // object, schema
+  //   category // string, schema name
+  // Returns: this instance
+  definition(schema, category) {
     this.schema = schema;
+    this.category = category;
     return this;
   }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -157,62 +157,56 @@ class Cursor {
   }
 
   count(
-    // Calculate count async
-    done // callback on done function(err, count)
+    // Calculate count
+    field // string, field to use for count or 'undefined'
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'count', field });
     return this;
   }
 
   sum(
-    // Calculate sum async
-    done // callback on done function(err, sum)
+    // Calculate sum
+    field // string, field to use for sum
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'sum', field });
     return this;
   }
 
   avg(
-    // Calculate avg async
-    done // callback on done function(err, avg)
+    // Calculate avg
+    field // string, field to use for avg
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'avg', field });
     return this;
   }
 
   max(
-    // Calculate max async
-    done // callback on done function(err, max)
+    // Calculate max
+    field // string, field to use for max
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'max', field });
     return this;
   }
 
   min(
     // Calculate min async
-    done // callback on done function(err, min)
+    field // string, field to use for min
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'min', field });
     return this;
   }
 
   median(
-    // Calculate median async
-    done // callback on done function(err, median)
+    // Calculate median
+    field // string, field to use for median
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'median', field });
     return this;
   }
 
@@ -306,6 +300,19 @@ class Cursor {
     this.jsql.push({ op: 'complement', cursor });
     this.parents.push(cursor);
     return this;
+  }
+
+  // Continue computations via i.e. MemoryCursor or other cursor
+  // to handle remaining operations unsupported by current cursor
+  //   data - array of rows to date
+  //   callback - function(err, dataset, cursor) to be called upon completion
+  continue(data, callback) {
+    new Cursor.MemoryCursor(data, {
+      parents: this.parents,
+      category: this.category,
+      schema: this.schema,
+      jsql: this.jsql,
+    }).fetch(callback);
   }
 
   fetch(

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -117,16 +117,6 @@ class Cursor {
     return this;
   }
 
-  find(
-    // Lazy functional find (legacy)
-    query, // find expression
-    options // find options
-    // Return: previous instance from chain
-  ) {
-    this.jsql.push({ op: 'find', query, options });
-    return this;
-  }
-
   sort(
     // Lazy functional sort
     fn // compare function
@@ -201,25 +191,6 @@ class Cursor {
     return this;
   }
 
-  median(
-    // Calculate median
-    field // string, field to use for median
-    // Return: previous instance from chain
-  ) {
-    this.jsql.push({ op: 'median', field });
-    return this;
-  }
-
-  mode(
-    // Calculate mode async
-    done // callback on done function(err, mode)
-    // Return: previous instance from chain
-  ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
-    return this;
-  }
-
   col(
     // Convert first column of dataset to Array
     // Return: previous instance from chain
@@ -240,7 +211,7 @@ class Cursor {
     // Get single first record from dataset
     // Return: previous instance from chain
   ) {
-    this.jsql.push({ op: 'one' });
+    this.jsql.push({ op: 'limit', count: 1 });
     return this;
   }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -228,21 +228,17 @@ class Cursor {
 
   col(
     // Convert first column of dataset to Array
-    done // callback on done function(err, mode)
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'col' });
     return this;
   }
 
   row(
     // Return first row from dataset
-    done // callback on done function(err, mode)
     // Return: previous instance from chain
   ) {
-    done = common.once(done);
-    done(new Error(core.NOT_IMPLEMENTED));
+    this.jsql.push({ op: 'row' });
     return this;
   }
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -4,14 +4,19 @@ const common = require('metarhia-common');
 
 const core = require('./core');
 
+const defaultOptions = {
+  category: null,
+  schema: null,
+  provider: null,
+};
+
 class Cursor {
-  constructor() {
-    this.parents = [];
-    this.provider = null;
+  constructor(options) {
     this.dataset = [];
     this.children = [];
-    this.jsql = [];
-    this.schema = null;
+    Object.assign(this, defaultOptions, options);
+    this.jsql = options && options.jsql ? options.jsql.slice() : [];
+    this.parents = options && options.parents ? options.parents.slice() : [];
   }
 
   definition(

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -102,11 +102,8 @@ class Cursor {
     query // filter expression
     // Return: new Cursor instance
   ) {
-    const cursor = new Cursor.MemoryCursor();
-    cursor.parents.push(this);
-    if (this.schema) cursor.definition(this.schema);
-    cursor.jsql.push({ op: 'select', query });
-    return cursor;
+    this.jsql.push({ op: 'select', query });
+    return this;
   }
 
   distinct(
@@ -271,6 +268,14 @@ class Cursor {
     this.jsql.push({ op: 'complement', cursor });
     this.parents.push(cursor);
     return this;
+  }
+
+  selectToMemory(query) {
+    return new Cursor.MemoryCursor([], {
+      jsql: query ? [{ op: 'select', query }] : [],
+      schema: this.schema,
+      parents: [this],
+    });
   }
 
   // Continue computations via i.e. MemoryCursor or other cursor

--- a/lib/fs.provider.js
+++ b/lib/fs.provider.js
@@ -149,10 +149,10 @@ class FsProvider extends StorageProvider {
 
   select(query, options, callback) {
     if (callback) callback();
-    const fc = new FsCursor();
-    fc.provider = this;
-    fc.jsql.push({ op: 'select', query, options });
-    return fc;
+    return new FsCursor({
+      provider: this,
+      jsql: [{ op: 'select', query, options }],
+    });
   }
 }
 

--- a/lib/memory.cursor.js
+++ b/lib/memory.cursor.js
@@ -45,9 +45,7 @@ class MemoryCursor extends Cursor {
     const process = dataset => {
       this.jsql.forEach(operation => {
         const fn = operations[operation.op];
-        if (fn) {
-          dataset = fn(operation, dataset);
-        }
+        dataset = fn(operation, dataset);
       });
       this.jsql.length = 0;
       done(null, dataset, this);

--- a/lib/memory.cursor.js
+++ b/lib/memory.cursor.js
@@ -61,7 +61,7 @@ class MemoryCursor extends Cursor {
         process(dataset);
       });
     } else {
-      const dataset = common.clone(this.dataset);
+      const dataset = common.duplicate(this.dataset);
       process(dataset);
     }
     return this;

--- a/lib/memory.cursor.js
+++ b/lib/memory.cursor.js
@@ -6,8 +6,8 @@ const operations = require('./operations');
 const { Cursor } = require('./cursor');
 
 class MemoryCursor extends Cursor {
-  constructor(dataset) {
-    super();
+  constructor(dataset, options) {
+    super(options);
     this.dataset = dataset;
     this.indices = {};
   }

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -59,6 +59,10 @@ const desc = (operation, dataset) => {
   return dataset;
 };
 
+const limit = (operation, dataset) => dataset.slice(0, operation.count);
+
+const offset = (operation, dataset) => dataset.slice(operation.offset);
+
 const projection = (operation, dataset) => (
   transformations.projection(operation.fields, dataset)
 );
@@ -96,6 +100,8 @@ module.exports = {
   distinct,
   order,
   desc,
+  limit,
+  offset,
   projection,
   row,
   col,

--- a/lib/pg.cursor.js
+++ b/lib/pg.cursor.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const transformations = require('./transformations');
+const { SelectBuilder } = require('./sqlgen');
+const { Cursor } = require('./cursor');
+
+const jsqlToSQLConverters = {
+  select: (op, query) => {
+    const constraints = transformations.constraints(op.query);
+    Object.keys(constraints).forEach(key => {
+      const [cond, value] = constraints[key];
+      if (cond === '!') return query.where(key, '!=', value);
+      return query.where(key, cond, value);
+    });
+  },
+  distinct: (op, query) => query.distinct(),
+  limit: (op, query) => query.limit(op.count),
+  offset: (op, query) => query.offset(op.offset),
+  count: (op, query) => query.count(),
+  sum: (op, query) => query.sum(op.field),
+  avg: (op, query) => query.avg(op.field),
+  max: (op, query) => query.max(op.field),
+  min: (op, query) => query.min(op.field),
+  order: (op, query) => op.fields.forEach(f => query.orderBy(f, 'ASC')),
+  desc: (op, query) => op.fields.forEach(f => query.orderBy(f, 'DESC')),
+};
+
+class PostgresCursor extends Cursor {
+  constructor(pgConnection, query, options) {
+    super(options);
+    this.pg = pgConnection;
+    if (query) this.category = query.category;
+  }
+
+  fetch(callback) {
+    if (!this.category) {
+      callback(new Error('Category name was not specified'));
+      return;
+    }
+    const pgquery = new SelectBuilder()
+      .from(this.category);
+
+    let i = 0;
+    for (; i < this.jsql.length; ++i) {
+      const op = this.jsql[i];
+      const conv = jsqlToSQLConverters[op.op];
+      if (!conv) {
+        --i;
+        break;
+      }
+      conv(op, pgquery, i, this);
+    }
+    this.pg.query(pgquery.toString(), (err, res) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+      this.jsql = this.jsql.slice(i);
+      if (this.jsql.length === 0) callback(null, res.rows, this);
+      else this.continue(res.rows, callback);
+    });
+  }
+}
+
+module.exports = { PostgresCursor };

--- a/lib/pg.utils.js
+++ b/lib/pg.utils.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const escapeString = value => {
+  let backslash = false;
+  let escaped = '\'';
+  for (const character of value) {
+    if (character === '\'') {
+      escaped += '\'\'';
+    } else if (character === '\\') {
+      escaped += '\\\\';
+      backslash = true;
+    } else {
+      escaped += character;
+    }
+  }
+  escaped += '\'';
+  return (backslash ? ` E${escaped}` : escaped);
+};
+
+const escapeValue = value => {
+  const type = typeof value;
+  if (type === 'number') return value;
+  if (type === 'string') return escapeString(value);
+  if (value instanceof Date) return `'${value.toISOString()}'`;
+  throw new TypeError('Unsupported value (${value}) type');
+};
+
+const PREDEFINED_DOMAINS = {
+  Time: 'time with time zone',
+  DateDay: 'date',
+  DateTime: 'timestamp with time zone',
+  Id: 'bigint',
+  JSON: 'json',
+};
+
+const IGNORED_DOMAINS = ['List', 'Enum', 'HashMap', 'HashSet'];
+
+const isValidIdentifier =
+  name => !'0123456789'.includes(name[0]); // TODO: implement validation
+
+module.exports = {
+  escapeString,
+  escapeValue,
+  PREDEFINED_DOMAINS,
+  IGNORED_DOMAINS,
+  isValidIdentifier,
+};

--- a/lib/sqlgen.js
+++ b/lib/sqlgen.js
@@ -1,0 +1,265 @@
+'use strict';
+
+const { iter } = require('metarhia-common');
+const { escapeValue } = require('./pg.utils');
+
+const allowedConditions = [
+  '=', '!=', '<', '<=', '>', '>=', 'LIKE',
+];
+
+const supportedOps = {
+  'select': Set,
+  'selectDistinct': null,
+  'count': Array,
+  'avg': Array,
+  'min': Array,
+  'max': Array,
+  'sum': Array,
+  'where': Array,
+  'groupBy': Set,
+  'orderBy': Set,
+  'from': null,
+  'limit': null,
+  'offset': null,
+};
+
+const functionHandlers = {
+  'count': op => `count(${op.field})`,
+  'avg': op => `avg(${op.field})`,
+  'min': op => `min(${op.field})`,
+  'max': op => `max(${op.field})`,
+  'sum': op => `sum(${op.field})`,
+};
+
+const checkType = (value, name, type) => {
+  if (typeof value !== type) {
+    throw new TypeError(
+      `Invalid '${name}' value (${value}) type, expected '${type}'`
+    );
+  }
+};
+
+class SelectBuilder {
+  constructor() {
+    this.operations = new Map();
+    for (const op of Object.keys(supportedOps)) {
+      const constructor = supportedOps[op];
+      this.operations.set(op, constructor ? new constructor() : null);
+    }
+  }
+
+  from(tableName) {
+    this.operations.set('from', tableName);
+    return this;
+  }
+
+  select(...fields) {
+    const select = this.operations.get('select');
+    iter(fields).forEach(f => select.add(f));
+    return this;
+  }
+
+  distinct() {
+    this.operations.set('selectDistinct', true);
+    return this;
+  }
+
+  where(key, cond, value) {
+    cond = cond.toUpperCase();
+    if (!allowedConditions.includes(cond)) {
+      throw new Error(`The operator "${cond}" is not permitted`);
+    }
+    this.operations.get('where').push({
+      key,
+      cond,
+      value: escapeValue(value),
+    });
+    return this;
+  }
+
+  whereNot(key, cond, value) {
+    cond = cond.toUpperCase();
+    if (!allowedConditions.includes(cond)) {
+      throw new Error(`The operator "${cond}" is not permitted`);
+    }
+    this.operations.get('where').push({
+      key,
+      cond,
+      value: escapeValue(value),
+      mod: 'NOT',
+    });
+    return this;
+  }
+
+  whereNull(key) {
+    this.operations.get('where').push({ key, cond: 'IS', value: 'null' });
+    return this;
+  }
+
+  whereNotNull(key) {
+    this.operations.get('where').push({
+      key,
+      cond: 'IS',
+      value: 'null',
+      mod: 'NOT',
+    });
+    return this;
+  }
+
+  whereIn(key, conds) {
+    this.operations.get('where').push({
+      key,
+      cond: 'IN',
+      value: `(${conds.map(escapeValue).join(', ')})`,
+    });
+    return this;
+  }
+
+  whereNotIn(key, conds) {
+    this.operations.get('where').push({
+      key,
+      cond: 'IN',
+      value: `(${conds.map(escapeValue).join(', ')})`,
+      mod: 'NOT',
+    });
+    return this;
+  }
+
+  orderBy(field, dir = 'ASC') {
+    dir = dir.toUpperCase();
+    this.operations.get('orderBy').add({ field, dir });
+    return this;
+  }
+
+  groupBy(...fields) {
+    const groupBy = this.operations.get('groupBy');
+    iter(fields).forEach(f => groupBy.add(f));
+    return this;
+  }
+
+  limit(limit) {
+    checkType(limit, 'limit', 'number');
+    this.operations.set('limit', limit);
+    return this;
+  }
+
+  offset(offset) {
+    checkType(offset, 'offset', 'number');
+    this.operations.set('offset', offset);
+    return this;
+  }
+
+  count(field = '*') {
+    this.operations.get('count').push({ field });
+    return this;
+  }
+
+  avg(field) {
+    this.operations.get('avg').push({ field });
+    return this;
+  }
+
+  min(field) {
+    this.operations.get('min').push({ field });
+    return this;
+  }
+
+  max(field) {
+    this.operations.get('max').push({ field });
+    return this;
+  }
+
+  sum(field) {
+    this.operations.get('sum').push({ field });
+    return this;
+  }
+
+  processSelect(query, clauses) {
+    if (clauses.size > 0) {
+      return query + ' ' + iter(clauses).reduce((acc, id) => acc + ', ' + id);
+    }
+    return query + ' *';
+  }
+
+  processOperations(query, operations, functionHandlers) {
+    for (const fn of Object.keys(functionHandlers)) {
+      const ops = operations.get(fn);
+      if (ops.length === 0) continue;
+      else if (query.endsWith(' *')) query = query.slice(0, -2);
+      else query += ',';
+      const handler = functionHandlers[fn];
+      // eslint-disable-next-line no-loop-func
+      query += ops.reduce((acc, op) => acc + handler(op, query) + ',', ' ')
+        .slice(0, -1);
+    }
+    return query;
+  }
+
+  processWhere(query, clauses) {
+    // TODO(lundibundi): support braces
+    query += ' WHERE';
+    const it = iter(clauses);
+    const firstClause = it.next().value;
+    if (firstClause.mod) query += ' ' + firstClause.mod;
+    query += ` ${firstClause.key} ${firstClause.cond} ${firstClause.value}`;
+    for (const clause of it) {
+      if (clause.or) query += ' OR';
+      else query += ' AND';
+      if (clause.mod) query += ' ' + clause.mod;
+      query += ` ${clause.key} ${clause.cond} ${clause.value}`;
+    }
+    return query;
+  }
+
+  processOrder(query, clauses) {
+    const it = iter(clauses);
+    const firstClause = it.next().value;
+    query += ` ORDER BY ${firstClause.field} ${firstClause.dir}`;
+    for (const order of it) {
+      query += `, ${order.field} ${order.dir}`;
+    }
+    return query;
+  }
+
+  toString() {
+    let query = 'SELECT';
+
+    if (this.operations.get('selectDistinct')) query += ' DISTINCT';
+
+    query = this.processSelect(query, this.operations.get('select'));
+
+    query = this.processOperations(query, this.operations, functionHandlers);
+
+    const tableName = this.operations.get('from');
+    if (!tableName) {
+      throw new Error('Cannot generate SQL, tableName is not defined');
+    }
+    query += ` FROM ${tableName}`;
+
+    const whereClauses = this.operations.get('where');
+    if (whereClauses.length > 0) {
+      query = this.processWhere(query, whereClauses);
+    }
+
+    const groupClauses = this.operations.get('groupBy');
+    if (groupClauses.size > 0) {
+      query += ' GROUP BY ' +
+        iter(groupClauses).reduce((acc, field) => acc + ', ' + field);
+    }
+
+    const orderClauses = this.operations.get('orderBy');
+    if (orderClauses.size > 0) {
+      query = this.processOrder(query, orderClauses);
+    }
+
+    const limit = this.operations.get('limit');
+    if (limit) query += ` LIMIT ${limit}`;
+
+    const offset = this.operations.get('offset');
+    if (offset) query += ` OFFSET ${offset}`;
+
+    return query;
+  }
+}
+
+module.exports = { SelectBuilder };

--- a/lib/transformations.js
+++ b/lib/transformations.js
@@ -42,15 +42,27 @@ const header = ds => {
 
 const projection = (
   // Dataset projection
-  meta, // projection metadata, example: ['Name']
+  meta, // projection metadata, example: ['Name'] or { toKey: [fromKey, funcs ]}
   ds // array of records, example: [ { Id: 1, Name: 'Marcus' } ]
   // Result: result array of records, example: [ { Name: 'Marcus' } ]
 ) => {
-  const fields = meta;
+  const complex = !Array.isArray(meta);
+  const fields = complex ? Object.keys(meta) : meta;
   return ds.map(record => {
     const row = {};
-    fields.forEach(field => {
-      row[field] = record[field];
+    fields.forEach(key => {
+      if (complex) {
+        const data = meta[key];
+        const fromKey = data[0];
+        const value = record[fromKey];
+        if (value !== undefined) {
+          row[key] = data.slice(1)
+            .reduce((acc, fn) => fn(acc), value);
+        }
+      } else {
+        const value = record[key];
+        if (value !== undefined) row[key] = record[key];
+      }
     });
     return row;
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,6 +1021,12 @@
         "node-releases": "^1.0.0-alpha.11"
       }
     },
+    "buffer-writer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1787,7 +1793,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2202,7 +2209,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2258,6 +2266,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2301,12 +2310,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2788,7 +2799,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -2936,7 +2947,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -3176,6 +3187,12 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "packet-reader": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
+      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=",
+      "dev": true
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -3240,6 +3257,62 @@
         "pify": "^2.0.0"
       }
     },
+    "pg": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
+      "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "1.0.1",
+        "packet-reader": "0.3.1",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+          "dev": true
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.3.tgz",
+      "integrity": "sha1-wCIDLIlJ8xKk+R+2QJzgQHa+Mlc=",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "dev": true,
+      "requires": {
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3281,6 +3354,33 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
+      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
+      "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -3792,6 +3892,15 @@
       "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -3900,7 +4009,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -4159,6 +4268,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "metatests": "^0.2.0"
+    "metatests": "^0.2.0",
+    "pg": "^7.4.3"
   }
 }

--- a/test/all.js
+++ b/test/all.js
@@ -2,3 +2,5 @@
 
 require('./memory');
 require('./system');
+require('./pg.cursor');
+require('./sqlgen.js');

--- a/test/memory.js
+++ b/test/memory.js
@@ -24,7 +24,7 @@ metatests.test('dataset operation', test => {
 });
 
 metatests.test('datasets tests', test => {
-  const mc1 = new gs.MemoryCursor(ds1, () => {});
+  const mc1 = new gs.MemoryCursor(ds1);
   const mc2 = mc1.clone();
   const ds1Expected = [{ Id: 1, Name: 'qwerty' }, { Id: 2 }];
   test.strictSame(mc1.dataset, ds1Expected, 'Dataset 1 should be changed');
@@ -34,7 +34,7 @@ metatests.test('datasets tests', test => {
 });
 
 metatests.test('sort order', test => {
-  const mc = new gs.MemoryCursor(ds1, () => {});
+  const mc = new gs.MemoryCursor(ds1);
   mc.clone()
     .order('Id')
     .fetch((err, data) => {
@@ -46,7 +46,7 @@ metatests.test('sort order', test => {
 });
 
 metatests.test('sort order desc', test => {
-  const mc = new gs.MemoryCursor(ds1, () => {});
+  const mc = new gs.MemoryCursor(ds1);
   mc.clone()
     .desc(['Id', 'Name'])
     .fetch((err, data) => {
@@ -115,7 +115,7 @@ metatests.test('cursor union', test => {
   const mcLanguages1 = new gs.MemoryCursor(languages1);
   const mcLanguages2 = new gs.MemoryCursor(languages2);
 
-  mcLanguages1.select({})
+  mcLanguages1.selectToMemory()
     .union(mcLanguages2)
     .order('Name')
     .fetch((err, data) => {
@@ -138,7 +138,7 @@ metatests.test('cursor intersection', test => {
   const mcLanguages1 = new gs.MemoryCursor(languages1);
   const mcLanguages2 = new gs.MemoryCursor(languages2);
 
-  mcLanguages1.select({})
+  mcLanguages1.selectToMemory()
     .intersection(mcLanguages2)
     .order('Name')
     .fetch((err, data) => {

--- a/test/memory.js
+++ b/test/memory.js
@@ -33,6 +33,40 @@ metatests.test('datasets tests', test => {
   test.end('datasets tests done');
 });
 
+metatests.test('limit test', test => {
+  const ds = [ { Id: 2 }, { Id: 3 } ];
+  new gs.MemoryCursor(ds)
+    .limit(1)
+    .fetch((err, data) => {
+      test.error(err);
+      test.strictSame(data, ds.slice(0, 1));
+      test.end();
+    });
+});
+
+metatests.test('offset test', test => {
+  const ds = [ { Id: 2 }, { Id: 3 } ];
+  new gs.MemoryCursor(ds)
+    .offset(1)
+    .fetch((err, data) => {
+      test.error(err);
+      test.strictSame(data, ds.slice(1));
+      test.end();
+    });
+});
+
+metatests.test('limit offset test', test => {
+  const ds = [ { Id: 2 }, { Id: 3 }, { Id: 4 }, { Id: 5 } ];
+  new gs.MemoryCursor(ds)
+    .offset(2)
+    .limit(1)
+    .fetch((err, data) => {
+      test.error(err);
+      test.strictSame(data, ds.slice(2, 3));
+      test.end();
+    });
+});
+
 metatests.test('sort order', test => {
   const mc = new gs.MemoryCursor(ds1);
   mc.clone()

--- a/test/memory.js
+++ b/test/memory.js
@@ -88,8 +88,10 @@ metatests.test('cursor schema', test => {
   metaschema.load('schemas/system', (err, schemas) => {
     test.error(err);
     metaschema.build(schemas);
-    const schema = metaschema.categories.get('Language').definition;
-    const mcLanguages = new gs.MemoryCursor(languages).definition(schema);
+    const schemaName = 'Language';
+    const schema = metaschema.categories.get(schemaName).definition;
+    const mcLanguages =
+      new gs.MemoryCursor(languages).definition(schema, schemaName);
     mcLanguages.select({ Locale: '> en' })
       .order('Name')
       .fetch((err, data, cursor) => {

--- a/test/pg.cursor.js
+++ b/test/pg.cursor.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { Pool } = require('pg');
+const { test } = require('metatests');
+const { sequential } = require('metasync');
+
+const { PostgresCursor } = require('..');
+
+const tableName = 'GSTestTable';
+
+const pool = new Pool({
+  user: process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASSWORD || '',
+  host: 'localhost',
+  database: process.env.DB_NAME || 'test_globalstorage_database',
+  port: process.env.DB_PORT || 5432,
+});
+
+const now = Date.now();
+const rowData = [
+  { id: 1, text: 'aaa', date: new Date(now - 1000) },
+  { id: 2, text: 'aaa', date: new Date(now - 1000) },
+  { id: 3, text: 'bbb', date: new Date(now - 5000) },
+  { id: 4, text: 'bbb', date: new Date(now - 5000) },
+  { id: 5, text: 'ccc', date: new Date(now - 1000) },
+];
+
+function prepareDB(callback) {
+  sequential([
+    (data, cb) => pool.query(`DROP TABLE IF EXISTS ${tableName}`, cb),
+    (data, cb) => pool.query(
+      `CREATE TABLE ${tableName} (
+         id int,
+         text varchar(255),
+         date timestamp with time zone)`,
+      cb
+    ),
+    (data, cb) => {
+      const insert =
+        `INSERT INTO ${tableName} (id, text, date) VALUES ` +
+        rowData
+          .map(row => `(${row.id}, '${row.text}', '${row.date.toISOString()}')`)
+          .join(', ');
+      pool.query(insert, cb);
+    },
+  ], callback);
+}
+
+test('PostgresCursor test', test => {
+
+  prepareDB(err => {
+    if (err) {
+      console.error('Cannot setup PostgresDB, skipping PostgresCursor tests.');
+      console.error(err);
+      test.end();
+      return;
+    }
+
+    test.endAfterSubtests();
+
+    test.beforeEach((test, callback) => {
+      pool.connect((err, client, done) => {
+        test.error(err);
+        const cursor = new PostgresCursor(client, { category: tableName });
+        callback({ cursor, done });
+      });
+    });
+    test.afterEach((test, callback) => {
+      test.context.done();
+      callback();
+    });
+
+    test.test('Select all', (test, { cursor }) => {
+      cursor.fetch((err, rows) => {
+        test.error(err);
+        test.strictSame(rows, rowData);
+        test.end();
+      });
+    });
+
+    test.test('Select few', (test, { cursor }) => {
+      const expected = rowData.filter(row => row.text === 'aaa');
+      cursor.select({ text: 'aaa' })
+        .fetch((err, rows) => {
+          test.error(err);
+          test.strictSame(rows, expected);
+          test.end();
+        });
+    });
+
+    test.test('Select few !=', (test, { cursor }) => {
+      const expected = rowData.filter(row => row.text !== 'aaa');
+      cursor.select({ text: '!aaa' })
+        .fetch((err, rows) => {
+          test.error(err);
+          test.strictSame(rows, expected);
+          test.end();
+        });
+    });
+
+    test.test('Select few row', (test, { cursor }) => {
+      const data = rowData.find(row => row.text === 'aaa');
+      const expected = Object.keys(data).map(k => data[k]);
+      cursor.select({ text: 'aaa' })
+        .row()
+        .fetch((err, rows) => {
+          test.error(err);
+          test.strictSame(rows, expected);
+          test.end();
+        });
+    });
+
+    test.test('Select few date', (test, { cursor }) => {
+      const date = rowData[0].date;
+      const expected = rowData
+        .filter(row => row.date.getTime() === date.getTime());
+      cursor.select({ date })
+        .fetch((err, rows) => {
+          test.error(err);
+          test.strictSame(rows, expected);
+          test.end();
+        });
+    });
+
+    test.on('done', () => pool.end());
+  });
+});

--- a/test/sqlgen.js
+++ b/test/sqlgen.js
@@ -1,0 +1,214 @@
+'use strict';
+
+const { testSync } = require('metatests');
+const { SelectBuilder } = require('../lib/sqlgen');
+
+testSync('Select tests', test => {
+  test.beforeEach(
+    (test, callback) => callback({ builder: new SelectBuilder() })
+  );
+
+  test.testSync('Simple all', (test, { builder }) => {
+    builder.from('table');
+    test.strictSame(builder.toString(), 'SELECT * FROM table');
+  });
+
+  test.testSync('Simple distinct select all', (test, { builder }) => {
+    builder.from('table').distinct();
+    test.strictSame(builder.toString(), 'SELECT DISTINCT * FROM table');
+  });
+
+  test.testSync('Simple field', (test, { builder }) => {
+    builder.select('a').from('table');
+    test.strictSame(builder.toString(), 'SELECT a FROM table');
+  });
+
+  test.testSync('Simple multiple field', (test, { builder }) => {
+    builder.select('a', 'b').from('table');
+    test.strictSame(builder.toString(), 'SELECT a, b FROM table');
+  });
+
+  test.testSync('Simple distinct multiple field', (test, { builder }) => {
+    builder.select('a', 'b').from('table').distinct();
+    test.strictSame(builder.toString(),
+      'SELECT DISTINCT a, b FROM table');
+  });
+
+  test.testSync('Select all single where', (test, { builder }) => {
+    builder.from('table').where('f1', '=', 3);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE f1 = 3');
+  });
+
+  test.testSync('Select all single where not', (test, { builder }) => {
+    builder.from('table').whereNot('f1', '=', 3);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE NOT f1 = 3');
+  });
+
+  test.testSync('Select all multiple where', (test, { builder }) => {
+    builder.from('table').where('f1', '=', 3).where('f2', '<', 'abc');
+    test.strictSame(builder.toString(),
+      // eslint-disable-next-line quotes
+      `SELECT * FROM table WHERE f1 = 3 AND f2 < 'abc'`);
+  });
+
+  test.testSync('Select all multiple where count', (test, { builder }) => {
+    builder.from('table')
+      .where('f1', '=', 3)
+      .where('f2', '<', 'abc')
+      .count('f0');
+    test.strictSame(builder.toString(),
+      // eslint-disable-next-line quotes
+      `SELECT count(f0) FROM table WHERE f1 = 3 AND f2 < 'abc'`);
+  });
+
+  test.testSync('Select few where avg', (test, { builder }) => {
+    builder.from('table')
+      .select('f1', 'f2')
+      .where('f1', '=', 3)
+      .avg('f0');
+    // Note that this is not a corerct postgre SQL query as the select fields
+    // are not present in the groupBy section. PG will fail with:
+    // 'ERROR: column "table.f1", "table.f2" must appear in the GROUP BY clause
+    //  or be used in an aggregate function'.
+    //  But this is not the job of an SQL generator to catch these
+    test.strictSame(builder.toString(),
+      'SELECT f1, f2, avg(f0) FROM table WHERE f1 = 3');
+  });
+
+  test.testSync('Select few where avg', (test, { builder }) => {
+    builder.from('table')
+      .select('f1', 'f2')
+      .where('f1', '=', 3)
+      .groupBy('f1', 'f2')
+      .min('f0');
+    test.strictSame(builder.toString(),
+      'SELECT f1, f2, min(f0) FROM table ' +
+      'WHERE f1 = 3 GROUP BY f1, f2');
+  });
+
+  test.testSync('Select all where max', (test, { builder }) => {
+    builder.from('table')
+      .where('f2', '=', 3)
+      .max('f1');
+    test.strictSame(builder.toString(),
+      'SELECT max(f1) FROM table WHERE f2 = 3');
+  });
+
+  test.testSync('Select all where limit', (test, { builder }) => {
+    builder.from('table')
+      .where('f2', '=', 3)
+      .limit(10);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE f2 = 3 LIMIT 10');
+  });
+
+  test.testSync('Select all where offset', (test, { builder }) => {
+    builder.from('table')
+      .where('f2', '=', 3)
+      .offset(10);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE f2 = 3 OFFSET 10');
+  });
+
+  test.testSync('Select all order offset', (test, { builder }) => {
+    builder.from('table')
+      .orderBy('f1')
+      .offset(10);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table ORDER BY f1 ASC OFFSET 10');
+  });
+
+  test.testSync('Select few order desc limit', (test, { builder }) => {
+    builder.from('table')
+      .select('f1', 'f2')
+      .orderBy('f1', 'desc')
+      .limit(10);
+    test.strictSame(builder.toString(),
+      'SELECT f1, f2 FROM table ORDER BY f1 DESC LIMIT 10');
+  });
+
+  test.testSync('Select few where order limit offset', (test, { builder }) => {
+    builder.from('table')
+      .select('f1')
+      .where('f2', '=', 3)
+      .offset(10)
+      .orderBy('f1')
+      .select('f3');
+    test.strictSame(builder.toString(),
+      'SELECT f1, f3 FROM table WHERE f2 = 3 ' +
+      'ORDER BY f1 ASC OFFSET 10');
+  });
+
+  test.testSync('Select where date', (test, { builder }) => {
+    const date = new Date(1537025908018); // 2018-09-15T15:38:28.018Z
+    const dateStr = date.toISOString();
+    builder.from('table')
+      .where('f2', '=', date, { date: 'date' });
+    test.strictSame(builder.toString(),
+      `SELECT * FROM table WHERE f2 = '${dateStr}'`);
+  });
+
+  test.testSync('Select where time with timezone', (test, { builder }) => {
+    const time = new Date(1537025908018); // 2018-09-15T15:38:28.018Z
+    const timeStr = time.toISOString();
+    builder.from('table')
+      .where('f2', '=', time, { date: 'time with time zone' });
+    test.strictSame(builder.toString(),
+      `SELECT * FROM table WHERE f2 = '${timeStr}'`);
+  });
+
+  test.testSync('Select where timestamp with timezone', (test, { builder }) => {
+    const time = new Date(1537025908018); // 2018-09-15T15:38:28.018Z
+    const timeStr = time.toISOString();
+    builder.from('table')
+      .where('f2', '=', time, { date: 'timestamp with time zone' });
+    test.strictSame(builder.toString(),
+      `SELECT * FROM table WHERE f2 = '${timeStr}'`);
+  });
+
+  test.testSync('Select where in numbers', (test, { builder }) => {
+    builder.from('table')
+      .whereIn('f1', [1, 2, 3]);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE f1 IN (1, 2, 3)');
+  });
+
+  test.testSync('Select where not in numbers', (test, { builder }) => {
+    builder.from('table')
+      .whereNotIn('f1', [1, 2, 3]);
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE NOT f1 IN (1, 2, 3)');
+  });
+
+  test.testSync('Select multiple operations', (test, { builder }) => {
+    builder.from('table')
+      .avg('f1')
+      .sum('f2');
+    test.strictSame(builder.toString(), 'SELECT avg(f1), sum(f2) FROM table');
+  });
+
+  test.testSync('Select multiple operations groupBy', (test, { builder }) => {
+    builder.from('table')
+      .avg('f1')
+      .sum('f2')
+      .groupBy('a', 'b');
+    test.strictSame(builder.toString(),
+      'SELECT avg(f1), sum(f2) FROM table GROUP BY a, b');
+  });
+
+  test.testSync('Select where like', (test, { builder }) => {
+    builder.from('table')
+      .where('f1', 'like', 'abc');
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE f1 LIKE \'abc\'');
+  });
+
+  test.testSync('Select where !=', (test, { builder }) => {
+    builder.from('table')
+      .where('f1', '!=', 'abc');
+    test.strictSame(builder.toString(),
+      'SELECT * FROM table WHERE f1 != \'abc\'');
+  });
+}, { parallelSubtests: true });

--- a/test/transformations.js
+++ b/test/transformations.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { testSync } = require('metatests');
+const { transformations } = require('../gs');
+
+testSync('must correctly apply projection', test => {
+  test.beforeEach((test, callback) => {
+    callback({
+      data: [
+        { k1: 1, k2: 2, k3: 5 },
+        { k1: 2, k2: 42, k3: 13 },
+        { k1: 1, k2: 11, k3: 5, k5: 16 },
+      ],
+    });
+  });
+
+  test.testSync('simple projection', (test, { data }) => {
+    const expected = [
+      { k1: 1 }, { k1: 2 }, { k1: 1 },
+    ];
+    const actual = transformations.projection(['k1'], data);
+    test.strictSame(actual, expected);
+  });
+
+  test.testSync('simple projection with missing', (test, { data }) => {
+    const expected = [
+      { k1: 1 }, { k1: 2 }, { k1: 1, k5: 16 },
+    ];
+    const actual = transformations.projection(['k1', 'k5', 'k6'], data);
+    test.strictSame(actual, expected);
+  });
+
+  test.testSync('complex projection no functions', (test, { data }) => {
+    const expected = [
+      { kk1: 1, kk2: 2 }, { kk1: 2, kk2: 42 }, { kk1: 1, kk2: 11 },
+    ];
+    const actual = transformations.projection(
+      { kk1: ['k1'], kk2: ['k2'] }, data
+    );
+    test.strictSame(actual, expected);
+  });
+
+
+  test.testSync('complex projection with functions', (test, { data }) => {
+    const expected = [
+      { kk1: 2, kk2: 6 }, { kk1: 4, kk2: 126 }, { kk1: 2, kk2: 33 },
+    ];
+    const actual = transformations.projection(
+      { kk1: ['k1', x => x * 2], kk2: ['k2', x => x * 3] }, data
+    );
+    test.strictSame(actual, expected);
+  });
+});


### PR DESCRIPTION
All of the commits not marked as 'fixup'/'squash' etc are to be landed as separate commits and can be reviewed separately. All of the (excluding PostgresCursor) commits are quite small.
Also, the current implementation of the PostgresCursor doesn't support 'parent' cursors as they are not really meaningless (with the way MemoryCursor implements them PostgresCursor will just degrade to MemoryCursor and therefore such implementation doesn't make sense for PostgresCursor).

TODO:
- [x] Move escapeValue to pg.utils.js
- [x] Rename pg-utils.js -> pg.utils.js
- [x] Change '!' jsql handling to `where key != value` (currently `where key is null`)