### PR TITLE
Remove query argument from PostgresCursor constructor

### DIFF
--- a/lib/pg.cursor.js
+++ b/lib/pg.cursor.js
@@ -26,10 +26,9 @@ const jsqlToSQLConverters = {
 };
 
 class PostgresCursor extends Cursor {
-  constructor(pgConnection, query, options) {
+  constructor(pgConnection, options) {
     super(options);
     this.pg = pgConnection;
-    if (query) this.category = query.category;
   }
 
   fetch(callback) {


### PR DESCRIPTION
This will make it consistent with other Cursor classes.