### PR TITLE
Clean up providers/cursors

### DIFF
--- a/lib/fs.provider.js
+++ b/lib/fs.provider.js
@@ -65,7 +65,7 @@ class FsProvider extends StorageProvider {
     callback();
   }
 
-  generateId(callback) {
+  takeId(callback) {
     callback = common.once(callback);
     callback(null, this.stat.next++);
     this.stat.count++;
@@ -83,7 +83,7 @@ class FsProvider extends StorageProvider {
 
   create(obj, callback) {
     callback = common.once(callback);
-    this.generateId((err, id) => {
+    this.takeId((err, id) => {
       if (err) {
         callback(err);
         return;

--- a/lib/memory.cursor.js
+++ b/lib/memory.cursor.js
@@ -39,23 +39,21 @@ class MemoryCursor extends Cursor {
     return this;
   }
 
-  fetch(done) {
-    done = common.once(done);
-
+  fetch(callback) {
     const process = dataset => {
       this.jsql.forEach(operation => {
         const fn = operations[operation.op];
         dataset = fn(operation, dataset);
       });
       this.jsql.length = 0;
-      done(null, dataset, this);
+      callback(null, dataset, this);
     };
 
     if (this.parents.length) {
       const parent = this.parents[0];
       parent.fetch((err, dataset) => {
         if (err) {
-          done(err);
+          callback(err);
           return;
         }
         process(dataset);

--- a/lib/memory.provider.js
+++ b/lib/memory.provider.js
@@ -1,19 +1,15 @@
 'use strict';
 
-const common = require('metarhia-common');
-
 const { StorageProvider } = require('./provider');
 
 class MemoryProvider extends StorageProvider {
   close(callback) {
-    callback = common.once(callback);
-    callback();
+    if (callback) callback();
   }
 
   create(obj, callback) {
-    callback = common.once(callback);
     this.dataset.push(obj);
-    callback();
+    if (callback) callback();
   }
 }
 

--- a/lib/memory.provider.js
+++ b/lib/memory.provider.js
@@ -2,7 +2,6 @@
 
 const common = require('metarhia-common');
 
-const core = require('./core');
 const { StorageProvider } = require('./provider');
 
 class MemoryProvider extends StorageProvider {
@@ -11,30 +10,10 @@ class MemoryProvider extends StorageProvider {
     callback();
   }
 
-  generateId(callback) {
-    callback = common.once(callback);
-    callback(new Error(core.NOT_IMPLEMENTED));
-  }
-
-  get(id, callback) {
-    callback = common.once(callback);
-    callback(new Error(core.NOT_IMPLEMENTED));
-  }
-
   create(obj, callback) {
     callback = common.once(callback);
     this.dataset.push(obj);
     callback();
-  }
-
-  update(obj, callback) {
-    callback = common.once(callback);
-    callback(new Error(core.NOT_IMPLEMENTED));
-  }
-
-  delete(id, callback) {
-    callback = common.once(callback);
-    callback(new Error(core.NOT_IMPLEMENTED));
   }
 }
 


### PR DESCRIPTION
Align fs.provider with general provider interface

* rename generateId -> takeId

Clean up MemoryProvider not implemented methods

* remove methods that just throw NOT_IMPLEMENTED as they already
  do so in the StorageProvider.

Clean up usages of common.done

* in MemoryProvider it's just called right away in a single place
  therefore there is no need to wrap a callback
* make callback in MemoryCursor.fetch required
  (make it fail with 'not a function' error)

All commits are to be landed.