### PR TITLE
Align MemoryCursor.count with Cursor interface

### DIFF
--- a/lib/memory.cursor.js
+++ b/lib/memory.cursor.js
@@ -33,12 +33,6 @@ class MemoryCursor extends Cursor {
     return this;
   }
 
-  count(done) {
-    done = common.once(done);
-    done(null, this.dataset.length);
-    return this;
-  }
-
   fetch(callback) {
     const process = dataset => {
       this.jsql.forEach(operation => {

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -63,6 +63,18 @@ const limit = (operation, dataset) => dataset.slice(0, operation.count);
 
 const offset = (operation, dataset) => dataset.slice(operation.offset);
 
+const count = (operation, dataset) => {
+  let length = 0;
+  if (!operation.field) {
+    length = dataset.length;
+  } else {
+    dataset.forEach(item => {
+      if (item.hasOwnProperty(operation.field)) length++;
+    });
+  }
+  return [length];
+};
+
 const projection = (operation, dataset) => (
   transformations.projection(operation.fields, dataset)
 );
@@ -102,6 +114,7 @@ module.exports = {
   desc,
   limit,
   offset,
+  count,
   projection,
   row,
   col,

--- a/test/memory.js
+++ b/test/memory.js
@@ -67,6 +67,28 @@ metatests.test('limit offset test', test => {
     });
 });
 
+metatests.test('count all test', test => {
+  const ds = [ { Id: 2, a: 1 }, { Id: 3, a: 2 }, { Id: 4 } ];
+  new gs.MemoryCursor(ds)
+    .count()
+    .fetch((err, data) => {
+      test.error(err);
+      test.strictSame(data, [ds.length]);
+      test.end();
+    });
+});
+
+metatests.test('count field test', test => {
+  const ds = [ { Id: 2, a: 1 }, { Id: 3, a: 2 }, { Id: 4 } ];
+  new gs.MemoryCursor(ds)
+    .count('a')
+    .fetch((err, data) => {
+      test.error(err);
+      test.strictSame(data, [ds.filter(d => d.hasOwnProperty('a')).length]);
+      test.end();
+    });
+});
+
 metatests.test('sort order', test => {
   const mc = new gs.MemoryCursor(ds1);
   mc.clone()


### PR DESCRIPTION
'count' now only queues count operation and will only return result
upon 'fetch'.

P.S. Don't pay attention to the branch name, forgot to rename.