### PR TITLE
Throw by default on abstract Cursor.fetch

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const common = require('metarhia-common');
-
 const errors = require('./errors');
 
 const defaultOptions = {
@@ -291,14 +289,11 @@ class Cursor {
     }).fetch(callback);
   }
 
-  fetch(
-    // Get results after applying consolidated jsql
-    done // callback function(err, dataset, cursor)
-    // Return: previous instance from chain
-  ) {
-    done = common.once(done);
-    done(new Error(errors.NOT_IMPLEMENTED), null, this);
-    return this;
+  // Get results after applying consolidated jsql
+  //   callback - function(err, dataset, cursor)
+  // Return: this instance
+  fetch(/* callback */) {
+    throw new Error(errors.NOT_IMPLEMENTED);
   }
 }
 


### PR DESCRIPTION
This will align fetch with other not-implemented methods in Cursor.