### PR TITLE
Escape values in queries from PostgresCursor

### DIFF
--- a/lib/pg.cursor.js
+++ b/lib/pg.cursor.js
@@ -49,7 +49,7 @@ class PostgresCursor extends Cursor {
       }
       conv(op, pgquery, i, this);
     }
-    this.pg.query(pgquery.toString(), (err, res) => {
+    this.pg.query(...pgquery.build(), (err, res) => {
       if (err) {
         callback(err);
         return;

--- a/lib/sqlgen.js
+++ b/lib/sqlgen.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { iter } = require('metarhia-common');
-const { escapeValue, escapeIdentifier } = require('./pg.utils');
+const { escapeIdentifier, generateQueryParams } = require('./pg.utils');
 
 const allowedConditions = [
   '=', '!=', '<', '<=', '>', '>=', 'LIKE',
@@ -39,6 +39,17 @@ const checkType = (value, name, type) => {
   }
 };
 
+const makeParamValue = (cond, value, params) => {
+  if (cond === 'IN') {
+    const startIndex = params.length || 1;
+    params.push(...value);
+    return '(' + generateQueryParams(value.length, startIndex) + ')';
+  } else {
+    params.push(value);
+    return `$${params.length}`;
+  }
+};
+
 class SelectBuilder {
   constructor() {
     this.operations = new Map();
@@ -71,7 +82,7 @@ class SelectBuilder {
     }
     this.operations.get('where').push({
       key: escapeIdentifier(key),
-      value: escapeValue(value),
+      value,
       cond,
     });
     return this;
@@ -84,7 +95,7 @@ class SelectBuilder {
     }
     this.operations.get('where').push({
       key: escapeIdentifier(key),
-      value: escapeValue(value),
+      value,
       cond,
       mod: 'NOT',
     });
@@ -114,7 +125,7 @@ class SelectBuilder {
     this.operations.get('where').push({
       key: escapeIdentifier(key),
       cond: 'IN',
-      value: `(${conds.map(escapeValue).join(', ')})`,
+      value: conds,
     });
     return this;
   }
@@ -123,7 +134,7 @@ class SelectBuilder {
     this.operations.get('where').push({
       key: escapeIdentifier(key),
       cond: 'IN',
-      value: `(${conds.map(escapeValue).join(', ')})`,
+      value: conds,
       mod: 'NOT',
     });
     return this;
@@ -200,18 +211,18 @@ class SelectBuilder {
     return query;
   }
 
-  processWhere(query, clauses) {
+  processWhere(query, clauses, params) {
     // TODO(lundibundi): support braces
     query += ' WHERE';
-    const it = iter(clauses);
-    const firstClause = it.next().value;
-    if (firstClause.mod) query += ' ' + firstClause.mod;
-    query += ` ${firstClause.key} ${firstClause.cond} ${firstClause.value}`;
-    for (const clause of it) {
-      if (clause.or) query += ' OR';
-      else query += ' AND';
-      if (clause.mod) query += ' ' + clause.mod;
-      query += ` ${clause.key} ${clause.cond} ${clause.value}`;
+    for (let i = 0; i < clauses.length; ++i) {
+      const clause = clauses[i];
+      if (i !== 0) {
+        if (clause.or) query += ' OR';
+        else query += ' AND';
+      }
+      if (clause.mod) query += ` ${clause.mod}`;
+      query += ` ${clause.key} ${clause.cond} ` +
+        makeParamValue(clause.cond, clause.value, params);
     }
     return query;
   }
@@ -226,7 +237,8 @@ class SelectBuilder {
     return query;
   }
 
-  toString() {
+  build() {
+    const params = [];
     let query = 'SELECT';
 
     if (this.operations.get('selectDistinct')) query += ' DISTINCT';
@@ -243,7 +255,7 @@ class SelectBuilder {
 
     const whereClauses = this.operations.get('where');
     if (whereClauses.length > 0) {
-      query = this.processWhere(query, whereClauses);
+      query = this.processWhere(query, whereClauses, params);
     }
 
     const groupClauses = this.operations.get('groupBy');
@@ -258,12 +270,16 @@ class SelectBuilder {
     }
 
     const limit = this.operations.get('limit');
-    if (limit) query += ` LIMIT ${limit}`;
+    if (limit) {
+      query += ` LIMIT ${makeParamValue(null, limit, params)}`;
+    }
 
     const offset = this.operations.get('offset');
-    if (offset) query += ` OFFSET ${offset}`;
+    if (offset) {
+      query += ` OFFSET ${makeParamValue(null, offset, params)}`;
+    }
 
-    return query;
+    return [query, params];
   }
 }
 

--- a/test/sqlgen.js
+++ b/test/sqlgen.js
@@ -10,47 +10,59 @@ testSync('Select tests', test => {
 
   test.testSync('Simple all', (test, { builder }) => {
     builder.from('table');
-    test.strictSame(builder.toString(), 'SELECT * FROM "table"');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Simple distinct select all', (test, { builder }) => {
     builder.from('table').distinct();
-    test.strictSame(builder.toString(), 'SELECT DISTINCT * FROM "table"');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT DISTINCT * FROM "table"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Simple field', (test, { builder }) => {
     builder.select('a').from('table');
-    test.strictSame(builder.toString(), 'SELECT "a" FROM "table"');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT "a" FROM "table"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Simple multiple field', (test, { builder }) => {
     builder.select('a', 'b').from('table');
-    test.strictSame(builder.toString(), 'SELECT "a", "b" FROM "table"');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT "a", "b" FROM "table"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Simple distinct multiple field', (test, { builder }) => {
     builder.select('a', 'b').from('table').distinct();
-    test.strictSame(builder.toString(),
-      'SELECT DISTINCT "a", "b" FROM "table"');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT DISTINCT "a", "b" FROM "table"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Select all single where', (test, { builder }) => {
     builder.from('table').where('f1', '=', 3);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE "f1" = 3');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f1" = $1');
+    test.strictSame(params, [3]);
   });
 
   test.testSync('Select all single where not', (test, { builder }) => {
     builder.from('table').whereNot('f1', '=', 3);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE NOT "f1" = 3');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE NOT "f1" = $1');
+    test.strictSame(params, [3]);
   });
 
   test.testSync('Select all multiple where', (test, { builder }) => {
     builder.from('table').where('f1', '=', 3).where('f2', '<', 'abc');
-    test.strictSame(builder.toString(),
-      // eslint-disable-next-line quotes
-      `SELECT * FROM "table" WHERE "f1" = 3 AND "f2" < 'abc'`);
+    const [query, params] = builder.build();
+    test.strictSame(query,
+      'SELECT * FROM "table" WHERE "f1" = $1 AND "f2" < $2');
+    test.strictSame(params, [3, 'abc']);
   });
 
   test.testSync('Select all multiple where count', (test, { builder }) => {
@@ -58,9 +70,10 @@ testSync('Select tests', test => {
       .where('f1', '=', 3)
       .where('f2', '<', 'abc')
       .count('f0');
-    test.strictSame(builder.toString(),
-      // eslint-disable-next-line quotes
-      `SELECT count("f0") FROM "table" WHERE "f1" = 3 AND "f2" < 'abc'`);
+    const [query, params] = builder.build();
+    test.strictSame(query,
+      'SELECT count("f0") FROM "table" WHERE "f1" = $1 AND "f2" < $2');
+    test.strictSame(params, [3, 'abc']);
   });
 
   test.testSync('Select few where avg', (test, { builder }) => {
@@ -73,8 +86,10 @@ testSync('Select tests', test => {
     // 'ERROR: column "table.f1", "table.f2" must appear in the GROUP BY clause
     //  or be used in an aggregate function'.
     //  But this is not the job of an SQL generator to catch these
-    test.strictSame(builder.toString(),
-      'SELECT "f1", "f2", avg("f0") FROM "table" WHERE "f1" = 3');
+    const [query, params] = builder.build();
+    test.strictSame(query,
+      'SELECT "f1", "f2", avg("f0") FROM "table" WHERE "f1" = $1');
+    test.strictSame(params, [3]);
   });
 
   test.testSync('Select few where avg', (test, { builder }) => {
@@ -83,41 +98,47 @@ testSync('Select tests', test => {
       .where('f1', '=', 3)
       .groupBy('f1', 'f2')
       .min('f0');
-    test.strictSame(builder.toString(),
+    const [query, params] = builder.build();
+    test.strictSame(query,
       'SELECT "f1", "f2", min("f0") FROM "table" ' +
-      'WHERE "f1" = 3 GROUP BY "f1", "f2"');
+      'WHERE "f1" = $1 GROUP BY "f1", "f2"');
+    test.strictSame(params, [3]);
   });
 
   test.testSync('Select all where max', (test, { builder }) => {
     builder.from('table')
       .where('f2', '=', 3)
       .max('f1');
-    test.strictSame(builder.toString(),
-      'SELECT max("f1") FROM "table" WHERE "f2" = 3');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT max("f1") FROM "table" WHERE "f2" = $1');
+    test.strictSame(params, [3]);
   });
 
   test.testSync('Select all where limit', (test, { builder }) => {
     builder.from('table')
       .where('f2', '=', 3)
       .limit(10);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE "f2" = 3 LIMIT 10');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f2" = $1 LIMIT $2');
+    test.strictSame(params, [3, 10]);
   });
 
   test.testSync('Select all where offset', (test, { builder }) => {
     builder.from('table')
       .where('f2', '=', 3)
       .offset(10);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE "f2" = 3 OFFSET 10');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f2" = $1 OFFSET $2');
+    test.strictSame(params, [3, 10]);
   });
 
   test.testSync('Select all order offset', (test, { builder }) => {
     builder.from('table')
       .orderBy('f1')
       .offset(10);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" ORDER BY "f1" ASC OFFSET 10');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" ORDER BY "f1" ASC OFFSET $1');
+    test.strictSame(params, [10]);
   });
 
   test.testSync('Select few order desc limit', (test, { builder }) => {
@@ -125,8 +146,10 @@ testSync('Select tests', test => {
       .select('f1', 'f2')
       .orderBy('f1', 'desc')
       .limit(10);
-    test.strictSame(builder.toString(),
-      'SELECT "f1", "f2" FROM "table" ORDER BY "f1" DESC LIMIT 10');
+    const [query, params] = builder.build();
+    test.strictSame(query,
+      'SELECT "f1", "f2" FROM "table" ORDER BY "f1" DESC LIMIT $1');
+    test.strictSame(params, [10]);
   });
 
   test.testSync('Select few where order limit offset', (test, { builder }) => {
@@ -136,58 +159,64 @@ testSync('Select tests', test => {
       .offset(10)
       .orderBy('f1')
       .select('f3');
-    test.strictSame(builder.toString(),
-      'SELECT "f1", "f3" FROM "table" WHERE "f2" = 3 ' +
-      'ORDER BY "f1" ASC OFFSET 10');
+    const [query, params] = builder.build();
+    test.strictSame(query,
+      'SELECT "f1", "f3" FROM "table" WHERE "f2" = $1 ' +
+      'ORDER BY "f1" ASC OFFSET $2');
+    test.strictSame(params, [3, 10]);
   });
 
   test.testSync('Select where date', (test, { builder }) => {
     const date = new Date(1537025908018); // 2018-09-15T15:38:28.018Z
-    const dateStr = date.toISOString();
     builder.from('table')
       .where('f2', '=', date, { date: 'date' });
-    test.strictSame(builder.toString(),
-      `SELECT * FROM "table" WHERE "f2" = '${dateStr}'`);
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f2" = $1');
+    test.strictSame(params, [date]);
   });
 
   test.testSync('Select where time with timezone', (test, { builder }) => {
     const time = new Date(1537025908018); // 2018-09-15T15:38:28.018Z
-    const timeStr = time.toISOString();
     builder.from('table')
       .where('f2', '=', time, { date: 'time with time zone' });
-    test.strictSame(builder.toString(),
-      `SELECT * FROM "table" WHERE "f2" = '${timeStr}'`);
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f2" = $1');
+    test.strictSame(params, [time]);
   });
 
   test.testSync('Select where timestamp with timezone', (test, { builder }) => {
     const time = new Date(1537025908018); // 2018-09-15T15:38:28.018Z
-    const timeStr = time.toISOString();
     builder.from('table')
       .where('f2', '=', time, { date: 'timestamp with time zone' });
-    test.strictSame(builder.toString(),
-      `SELECT * FROM "table" WHERE "f2" = '${timeStr}'`);
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f2" = $1');
+    test.strictSame(params, [time]);
   });
 
   test.testSync('Select where in numbers', (test, { builder }) => {
     builder.from('table')
       .whereIn('f1', [1, 2, 3]);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE "f1" IN (1, 2, 3)');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f1" IN ($1, $2, $3)');
+    test.strictSame(params, [1, 2, 3]);
   });
 
   test.testSync('Select where not in numbers', (test, { builder }) => {
     builder.from('table')
       .whereNotIn('f1', [1, 2, 3]);
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE NOT "f1" IN (1, 2, 3)');
+    const [query, params] = builder.build();
+    test.strictSame(query,
+      'SELECT * FROM "table" WHERE NOT "f1" IN ($1, $2, $3)');
+    test.strictSame(params, [1, 2, 3]);
   });
 
   test.testSync('Select multiple operations', (test, { builder }) => {
     builder.from('table')
       .avg('f1')
       .sum('f2');
-    test.strictSame(builder.toString(),
-      'SELECT avg("f1"), sum("f2") FROM "table"');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT avg("f1"), sum("f2") FROM "table"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Select multiple operations groupBy', (test, { builder }) => {
@@ -195,21 +224,25 @@ testSync('Select tests', test => {
       .avg('f1')
       .sum('f2')
       .groupBy('a', 'b');
-    test.strictSame(builder.toString(),
+    const [query, params] = builder.build();
+    test.strictSame(query,
       'SELECT avg("f1"), sum("f2") FROM "table" GROUP BY "a", "b"');
+    test.strictSame(params, []);
   });
 
   test.testSync('Select where like', (test, { builder }) => {
     builder.from('table')
       .where('f1', 'like', 'abc');
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE "f1" LIKE \'abc\'');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f1" LIKE $1');
+    test.strictSame(params, ['abc']);
   });
 
   test.testSync('Select where !=', (test, { builder }) => {
     builder.from('table')
       .where('f1', '!=', 'abc');
-    test.strictSame(builder.toString(),
-      'SELECT * FROM "table" WHERE "f1" != \'abc\'');
+    const [query, params] = builder.build();
+    test.strictSame(query, 'SELECT * FROM "table" WHERE "f1" != $1');
+    test.strictSame(params, ['abc']);
   });
 }, { parallelSubtests: true });


### PR DESCRIPTION
Modifies SelectBuilder to use escaping in generated queries.
toString() is changed to build() as that's more appropriate name.