### PR TITLE
Store schemas as strings instead of JSON

### DIFF
--- a/schemas/system/Schema.schema
+++ b/schemas/system/Schema.schema
@@ -1,7 +1,7 @@
 System({
   Category: { category: 'Category', lookup: true, required: true, index: true },
   Version: { domain: 'Version', required: true, index: true },
-  Schema: { domain: 'JSON', required: true },
+  Schema: { domain: 'Source', required: true },
 
   NaturalKey: Unique('Category', 'Version')
 })


### PR DESCRIPTION
Using JSON will lead to loss of information about schema, due to class names not being serialized by JSON, because of that decorators would be lost when schemas are retrieved from db.