### PR TITLE
Update Travis config to use the current Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
   - 6
   - 8
-  - 9
   - 10
+  - 11
 sudo: false
 services:
   - postgresql


### PR DESCRIPTION
Remove end-of-life Node.js 9 and add the current Node.js 11.