### PR TITLE
Use row locking in PostgresProvider#takeId()

### DIFF
--- a/lib/pg.provider.js
+++ b/lib/pg.provider.js
@@ -148,10 +148,11 @@ class PostgresProvider extends StorageProvider {
   takeId(client, callback) {
     const takeIdQuery = 'UPDATE "Identifier"' +
       ' SET "Status" = \'Init\', "Change" = CURRENT_TIMESTAMP' +
-      ' WHERE "Id" = (SELECT min("Id")' +
+      ' WHERE "Id" = (SELECT "Id"' +
       ' FROM "Identifier"' +
       ' WHERE "Status" = \'Prealloc\' AND "StorageKind" = \'Master\'' +
-      ') RETURNING "Id"';
+      ' ORDER BY "Id" LIMIT 1' +
+      ' FOR UPDATE SKIP LOCKED) RETURNING "Id"';
     client.query(takeIdQuery, (err, res) => {
       if (err) {
         callback(err);

--- a/lib/pg.provider.js
+++ b/lib/pg.provider.js
@@ -103,7 +103,7 @@ class PostgresProvider extends StorageProvider {
         });
       },
       (ctx, callback) => {
-        metasync.series(
+        metasync.each(
           categories,
           (value, callback) => {
             this.create('Category', value, (err, id) => {
@@ -117,7 +117,7 @@ class PostgresProvider extends StorageProvider {
         );
       },
       (ctx, callback) => {
-        metasync.series(
+        metasync.each(
           common.iter(categories).flatMap(c => {
             const actions = getCategoryActions(
               this.gs.schema.categories.get(c.Name).definition

--- a/sql/id.sql
+++ b/sql/id.sql
@@ -27,13 +27,19 @@ DECLARE
     last_id        bigint;
     server_id      bigint;
     id_bit_length  integer;
+    lock_obtained  boolean;
 BEGIN
     max_count := TG_ARGV[0]::bigint;
     refill_percent := TG_ARGV[1]::integer;
     server_id := TG_ARGV[2]::bigint;
     id_bit_length := TG_ARGV[3]::integer;
 
-    SELECT count(1) INTO prealloc_count
+    SELECT pg_try_advisory_xact_lock(0) INTO lock_obtained;
+    IF NOT lock_obtained THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT count(*) INTO prealloc_count
     FROM "Identifier"
     WHERE "Status" = 'Prealloc';
 


### PR DESCRIPTION
Also modify `idgen()` SQL trigger function to use transaction-level
advisory locks to avoid id generation conflicts, and use `count(*)`
instead of `count(1)`.