### PR TITLE
Add support for Include categories in PostgresProvider#get()

### DIFF
--- a/lib/pg.provider.js
+++ b/lib/pg.provider.js
@@ -204,15 +204,13 @@ class PostgresProvider extends StorageProvider {
         return;
       }
 
-      const objectQuery = `SELECT * FROM ${escapeIdentifier(category)}` +
-        ' WHERE "Id" = $1';
-      this.pool.query(objectQuery, [id], (err, res) => {
+      this.select(category, { [`${category}.Id`]: id }).fetch((err, rows) => {
         if (err) {
           callback(err);
           return;
         }
 
-        if (res.rowCount === 0) {
+        if (rows.length === 0) {
           callback(new GSError(
             errorCodes.NOT_FOUND,
             `No object with Id ${id} available`
@@ -220,7 +218,7 @@ class PostgresProvider extends StorageProvider {
           return;
         }
 
-        callback(null, res.rows[0]);
+        callback(null, rows[0]);
       });
     });
   }

--- a/test/pg.js
+++ b/test/pg.js
@@ -175,33 +175,40 @@ prepareDB(err => {
       });
     });
 
-    let includeId;
+    const includeObj = {
+      Name: 'Metarhia',
+      Address: {
+        Country: 'Ukraine',
+        City: 'Kiev',
+      },
+    };
 
     test.test('gs.create with Include categories', test => {
-      provider.create('Company', {
-        Name: 'Metarhia',
-        Address: {
-          Country: 'Ukraine',
-          City: 'Kiev',
-        },
-      }, (err, id) => {
+      provider.create('Company', includeObj, (err, id) => {
         test.error(err);
         test.assert(id);
-        includeId = id;
+        includeObj.Id = id;
         test.end();
       });
     });
 
     test.test('gs.set with Include categories', test => {
-      provider.set({
-        Id: includeId,
-        Name: 'iBusiness',
-        Address: {
-          Country: 'USA',
-          City: 'San Francisco',
-        },
-      }, err => {
+      includeObj.Name = 'iBusiness';
+      includeObj.Address = {
+        Id: includeObj.Id,
+        Country: 'USA',
+        City: 'San Francisco',
+      };
+      provider.set(includeObj, err => {
         test.error(err);
+        test.end();
+      });
+    });
+
+    test.test('gs.get with Include categories', test => {
+      provider.get(includeObj.Id, (err, obj) => {
+        test.error(err);
+        test.strictSame(obj, includeObj);
         test.end();
       });
     });


### PR DESCRIPTION
Use PostgresProvider#select() inside this method to reduce code
duplication.