### PR TITLE
Add new error code for internal provider errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const codes = {
+  INTERNAL_PROVIDER_ERROR: 999,
   NOT_IMPLEMENTED: 1000,
   NOT_FOUND: 1001,
   INVALID_SCHEMA: 1002,

--- a/lib/pg.cursor.js
+++ b/lib/pg.cursor.js
@@ -6,6 +6,7 @@ const transformations = require('./transformations');
 const { SelectBuilder } = require('./sqlgen');
 const { Cursor } = require('./cursor');
 const { fitInSchema } = require('./pg.utils');
+const { GSError, codes: errorCodes } = require('./errors');
 
 const jsqlToSQLConverters = {
   select: (op, query) => {
@@ -70,7 +71,7 @@ class PostgresCursor extends Cursor {
     //       querying from multiple tables at once
     this.pg.query(...pgquery.build(), (err, res) => {
       if (err) {
-        callback(err);
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
         return;
       }
       this.jsql = this.jsql.slice(i);

--- a/lib/pg.provider.js
+++ b/lib/pg.provider.js
@@ -73,14 +73,18 @@ class PostgresProvider extends StorageProvider {
   [recreateIdTrigger](maxIdCount, refillPercent, callback) {
     this.pool.query('DROP TRIGGER IF EXISTS idgen ON "Identifier"', err => {
       if (err) {
-        callback(err);
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
       }
 
       this.pool.query(
         'SELECT trigger_creator($1, $2, $3, $4)',
         [maxIdCount, refillPercent, this.serverSuffix, this.serverBitmaskSize],
         err => {
-          callback(err);
+          if (err) {
+            callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+          } else {
+            callback();
+          }
         }
       );
     });
@@ -164,7 +168,11 @@ class PostgresProvider extends StorageProvider {
         },
       ],
       err => {
-        callback(err);
+        if (err) {
+          callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+        } else {
+          callback();
+        }
       }
     );
   }
@@ -211,7 +219,7 @@ class PostgresProvider extends StorageProvider {
       ' "Identifier"."Id" = $1';
     this.pool.query(categoryQuery, [id], (err, res) => {
       if (err) {
-        callback(err);
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
         return;
       }
       if (res.rowCount === 0) {
@@ -297,7 +305,11 @@ class PostgresProvider extends StorageProvider {
           `.${escapeIdentifier(leftCategory)} = $1`,
         [id],
         (err, res) => {
-          callback(err, res && res.rows);
+          if (err) {
+            callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+          } else {
+            callback(null, res.rows);
+          }
         }
       );
     });
@@ -354,7 +366,7 @@ class PostgresProvider extends StorageProvider {
 
       this.pool.connect((err, client, done) => {
         if (err) {
-          callback(err);
+          callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
           return;
         }
         metasync.sequential(
@@ -387,9 +399,16 @@ class PostgresProvider extends StorageProvider {
             if (err) {
               client.query('ROLLBACK', rollbackError => {
                 if (rollbackError) {
-                  callback(rollbackError);
+                  callback(
+                    new GSError(
+                      errorCodes.INTERNAL_PROVIDER_ERROR,
+                      rollbackError
+                    )
+                  );
                 } else {
-                  callback(err);
+                  callback(
+                    new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err)
+                  );
                 }
                 done();
               });
@@ -398,7 +417,7 @@ class PostgresProvider extends StorageProvider {
 
             client.query('COMMIT', err => {
               if (err) {
-                callback(err);
+                callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
               } else {
                 callback(null, ctx.id);
               }
@@ -485,7 +504,7 @@ class PostgresProvider extends StorageProvider {
     if (isGlobalCategory(categoryDefinition)) {
       this.pool.connect((err, client, done) => {
         if (err) {
-          callback(err);
+          callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
           return;
         }
         metasync.sequential(
@@ -543,9 +562,16 @@ class PostgresProvider extends StorageProvider {
             if (err) {
               client.query('ROLLBACK', rollbackError => {
                 if (rollbackError) {
-                  callback(rollbackError);
+                  callback(
+                    new GSError(
+                      errorCodes.INTERNAL_PROVIDER_ERROR,
+                      rollbackError
+                    )
+                  );
                 } else {
-                  callback(err);
+                  callback(
+                    new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err)
+                  );
                 }
                 done();
               });
@@ -554,7 +580,7 @@ class PostgresProvider extends StorageProvider {
 
             client.query('COMMIT', err => {
               if (err) {
-                callback(err);
+                callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
               } else {
                 callback(null, ctx.id);
               }
@@ -564,7 +590,13 @@ class PostgresProvider extends StorageProvider {
         );
       });
     } else {
-      createRecord(category, obj, this.pool, null, callback);
+      createRecord(category, obj, this.pool, null, (err, res) => {
+        if (err) {
+          callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+        } else {
+          callback(null, res);
+        }
+      });
     }
   }
 
@@ -600,7 +632,11 @@ class PostgresProvider extends StorageProvider {
       `ROW (${generateQueryParams(fields.length, whereParams.length + 1)})` +
       where;
     this.pool.query(updateQuery, whereParams.concat(values), (err, res) => {
-      callback(err, res && res.rowCount);
+      if (err) {
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+      } else {
+        callback(null, res.rowCount);
+      }
     });
   }
 
@@ -631,7 +667,11 @@ class PostgresProvider extends StorageProvider {
       query
     );
     this.pool.query(deleteQuery, queryParams, (err, res) => {
-      callback(err, res && res.rowCount);
+      if (err) {
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+      } else {
+        callback(null, res.rowCount);
+      }
     });
   }
 
@@ -659,7 +699,11 @@ class PostgresProvider extends StorageProvider {
       `INSERT INTO ${escapeIdentifier(tableName)}` +
       ` VALUES ${generateLinkQueryParams(toIds.length)}`;
     this.pool.query(query, [fromId, ...toIds], err => {
-      callback(err);
+      if (err) {
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+      } else {
+        callback();
+      }
     });
   }
 
@@ -688,7 +732,11 @@ class PostgresProvider extends StorageProvider {
       ` WHERE ${escapeIdentifier(category)} = $1 AND` +
       ` ${escapeIdentifier(field)} = ANY ($2)`;
     this.pool.query(query, [fromId, toIds], err => {
-      callback(err);
+      if (err) {
+        callback(new GSError(errorCodes.INTERNAL_PROVIDER_ERROR, err));
+      } else {
+        callback();
+      }
     });
   }
 


### PR DESCRIPTION
Also wrap all of the internal `PostgresProvider` errors received from
the `pg` package in `GSError` with newly added error code.