### PR TITLE
Fix usage of metaschema.extractDecorator() on undefined

### DIFF
--- a/lib/pg.provider.js
+++ b/lib/pg.provider.js
@@ -477,8 +477,9 @@ class PostgresProvider extends StorageProvider {
       const categoryDefinition = this.schema.categories.get(category)
         .definition;
       let fields = Object.keys(obj).filter(key => {
+        if (key === 'Id') return false;
         const decorator = extractDecorator(categoryDefinition[key]);
-        return key !== 'Id' && decorator !== 'Include' && decorator !== 'Many';
+        return decorator !== 'Include' && decorator !== 'Many';
       });
       const values = fields.map(key => obj[key]);
       if (id) {


### PR DESCRIPTION
It has led to crashes when passing the object with `Id` field to `PostgresProvider#create()`.