### PR TITLE
Align StorageProvider#execute() signature with other methods

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -6,6 +6,7 @@ const { GSError, codes: errorCodes } = require('./errors');
 const {
   createRemoteProviderJstpApi,
 } = require('./remote.provider.jstp.api.js');
+const { runIfFn } = require('./utils');
 
 // Abstract Storage Provider
 class StorageProvider {
@@ -218,36 +219,48 @@ class StorageProvider {
   //   callback <Function>
   //     error <Error> | <null>
   //     result <any>
-  execute(category, action, actionArgs, callback) {
-    let foundAction;
-    if (category === null) {
-      foundAction = this.schema.actions.get(action);
-    } else {
-      const categorySchema = this.schema.get(category);
-      if (!categorySchema) {
+  //   permissionChecker - <Function>, optional
+  //     category - <string>
+  //     action - <string>
+  //     callback - <Function>
+  //       err - <Error> | <null>
+  execute(category, action, actionArgs, callback, permissionChecker) {
+    runIfFn(permissionChecker, category, action, err => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      let foundAction;
+      if (category === null) {
+        foundAction = this.schema.actions.get(action);
+      } else {
+        const categorySchema = this.schema.categories.get(category);
+        if (!categorySchema) {
+          callback(new GSError(errorCodes.NOT_FOUND));
+          return;
+        }
+        foundAction = categorySchema.actions.get(action);
+      }
+      if (!foundAction) {
         callback(new GSError(errorCodes.NOT_FOUND));
         return;
       }
-      foundAction = categorySchema.actions.get(action);
-    }
-    if (!foundAction) {
-      callback(new GSError(errorCodes.NOT_FOUND));
-      return;
-    }
-    const args = actionArgs[1];
-    const error = this.schema.validate('action', foundAction, args);
-    if (error) {
-      process.nextTick(
-        callback,
-        new GSError(
-          errorCodes.INVALID_SCHEMA,
-          `Invalid arguments provided: ${error}`
-        )
-      );
-      return;
-    }
-    const { Execute: execute } = foundAction.definition;
-    execute(...actionArgs, callback);
+      const args = actionArgs[1];
+      const error = this.schema.validate('action', foundAction, args);
+      if (error) {
+        process.nextTick(
+          callback,
+          new GSError(
+            errorCodes.INVALID_SCHEMA,
+            `Invalid arguments provided: ${error}`
+          )
+        );
+        return;
+      }
+      const { Execute: execute } = foundAction.definition;
+      execute(...actionArgs, callback);
+    });
   }
 
   // Get system suffix for given id

--- a/lib/remote.provider.jstp.api.js
+++ b/lib/remote.provider.jstp.api.js
@@ -273,26 +273,29 @@ const createRemoteProviderJstpApi = (gsProvider, cursorFactory) => ({
       }
       const { session } = connection;
       const userId = session.get('userId');
-      checkExecutePermission(
-        gsProvider,
+      gsProvider.execute(
         category,
         action,
-        userId,
-        (err, ok) => {
-          if (err) {
-            callback(jstp.ERR_INTERNAL_API_ERROR);
-          } else if (!ok) {
-            callback(errorCodes.INSUFFICIENT_PERMISSIONS);
-          } else {
-            gsProvider.execute(
-              category,
-              action,
-              [session, args],
-              (err, ...res) => {
-                callback(err && (err.code || err), ...res);
+        [session, args],
+        (err, ...res) => {
+          callback(err && (err.code || err), ...res);
+        },
+        (category, action, callback) => {
+          checkExecutePermission(
+            gsProvider,
+            category,
+            action,
+            userId,
+            (err, ok) => {
+              if (err) {
+                callback(jstp.ERR_INTERNAL_API_ERROR);
+              } else if (!ok) {
+                callback(errorCodes.INSUFFICIENT_PERMISSIONS);
+              } else {
+                callback();
               }
-            );
-          }
+            }
+          );
         }
       );
     },


### PR DESCRIPTION
Also, fix StorageProvider#execute() throwing when executing non-public
actions.