### PR TITLE
Fix sensitive data removal in logs for operations without known category

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -30,6 +30,8 @@ const prepareForLogging = (provider, record) => {
         removeSensitiveData(schema.definition.Returns, record.Response[0]),
       ];
     }
+  } else if (!category) {
+    return;
   } else if (operation === 'Read') {
     let schema = ms.categories.get(category);
     if (record.getDetails) schema = schema.definition[record.getDetails];


### PR DESCRIPTION
This is a temporary solution, we still have to remove sensitive data
from such operations, so we need a way to propagate category name into
the logging.