### PR TITLE
Fix possible crashes on sensitive data removal

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -39,7 +39,9 @@ const prepareForLogging = (provider, record) => {
     return;
   } else if (operation === 'Read') {
     let schema = ms.categories.get(category);
-    if (record.getDetails) schema = schema.definition[record.getDetails];
+    if (schema && record.getDetails)
+      schema = schema.definition[record.getDetails];
+    if (!schema) return;
     if (Array.isArray(record.Response)) {
       record.Response = record.Response.map(record =>
         removeSensitiveData(schema.definition, record)
@@ -51,6 +53,7 @@ const prepareForLogging = (provider, record) => {
     }
   } else {
     const schema = ms.categories.get(category);
+    if (!schema) return;
     const { Query: query, Patch: patch } = record;
     if (query && !query.linkDetails && !query.unlinkDetails) {
       record.Query = removeSensitiveData(schema.definition, query);


### PR DESCRIPTION
This patch fixes possible crashes when logging operations on categories unknown to the schema.