### PR TITLE
Draft Move CRDTs from prototype to globalstorage

### DIFF
--- a/lib/crdt/counter/delta.js
+++ b/lib/crdt/counter/delta.js
@@ -1,0 +1,70 @@
+'use strict';
+
+// should it be imported from metaschema?
+const { COUNTER } = require('./type');
+const DELTA_COUNTER = 'delta-counter';
+
+const init = () => ({
+  // corresponds to the type in the schema
+  type: COUNTER,
+  // corresponds to the CRDT strategy
+  strategy: DELTA_COUNTER,
+  storage: new Map(),
+});
+
+const value = (state) => {
+  const values = Array.from(state.values());
+  return values.reduce((acc, current) => acc + current, 0);
+};
+
+const keysUnion = (state1, state2) => {
+  const keys = new Set();
+  for (const key of state1.keys()) keys.add(key);
+  for (const key of state2.keys()) keys.add(key);
+  return keys;
+};
+
+const join = (state1, delta1) => {
+  const result = init();
+  for (const key of keysUnion(state1, delta1)) {
+    const value1 = state1.storage.get(key) || 0;
+    const value2 = delta1.storage.get(key) || 0;
+    result.storage.set(key, Math.max(value1, value2));
+  }
+  return result;
+};
+
+const delta = (state1, state2) => {
+  const result = init();
+  for (const key of keysUnion(state1, state2)) {
+    const value1 = state1.storage.get(key) || 0;
+    const value2 = state2.storage.get(key) || 0;
+    result.storage.set(key, value1 - value2);
+  }
+  return result;
+};
+
+const inc = (id, state, increment = 1) => {
+  const delta = init();
+  const value = state.storage.get(id) || 0;
+  delta.storage.set(id, value + increment);
+  return delta;
+};
+
+const create = () => {
+  const state = init();
+  return {
+    state: () => state,
+    inc: (id, increment = 1) => inc(id, state, increment),
+    join: (delta) => join(state, delta),
+    delta: (state2) => delta(state, state2),
+  };
+};
+
+module.exports = {
+  init,
+  create,
+  value,
+  join,
+  inc,
+};

--- a/lib/crdt/counter/operation-accumulated.js
+++ b/lib/crdt/counter/operation-accumulated.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { COUNTER } = require('./type');
+
+const OPERATION_ACCUMULATED_COUNTER = 'operation-accumulated-counter';
+
+const init = () => ({
+  // corresponds to the type in the schema
+  type: COUNTER,
+  // corresponds to the CRDT strategy
+  strategy: OPERATION_ACCUMULATED_COUNTER,
+  value: 0,
+  delta: 0,
+});
+
+const update = (counter, delta) => {
+  counter.value += delta;
+  counter.delta += delta;
+};
+
+const value = (counter) => counter.value;
+
+const merge = (counter, delta) => {
+  counter.value += delta;
+  return counter;
+};
+
+const sync = (counter, callback) => {
+  callback(counter.delta);
+  counter.delta = 0;
+};
+
+const create = () => {
+  const counter = init();
+  return {
+    state: () => counter,
+    value: () => counter.value,
+    inc: (delta = 1) => update(counter, delta),
+    dec: (delta = 1) => update(counter, -delta),
+    // Do we actually need both sync and merge?
+    merge: (delta) => merge(counter, delta),
+    sync: (callback) => sync(counter, callback),
+  };
+};
+
+module.exports = { create, init, update, merge, sync, value };

--- a/lib/crdt/counter/operation.js
+++ b/lib/crdt/counter/operation.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { COUNTER } = require('./type');
+const OPERATION_COUNTER = 'operation-counter';
+
+const init = (id) => ({
+  // corresponds to the type in the schema
+  type: COUNTER,
+  // corresponds to the CRDT strategy
+  strategy: OPERATION_COUNTER,
+  id,
+  seq: 0,
+  ops: [],
+  applied: new Set(),
+});
+
+const update = ({ id, seq, ops, applied }, delta) => {
+  const opId = `${id}:${seq++}`;
+  ops.push({ id: opId, delta });
+  applied.add(opId);
+};
+
+const merge = (state, ops) => {
+  const { ops: stateOps, applied } = state;
+  for (const op of ops) {
+    if (!applied.has(op.id)) {
+      stateOps.push(op);
+      applied.add(op.id);
+    }
+  }
+  return state;
+};
+
+const value = ({ ops }) => ops.reduce((sum, { delta }) => sum + delta, 0);
+
+const operations = ({ ops }) => ops;
+
+const create = (id) => {
+  const counter = init(id);
+  return {
+    state: () => counter,
+    value: () => value(counter),
+    operations: () => operations(counter),
+    inc: (delta = 1) => update(counter, delta),
+    dec: (delta = 1) => update(counter, -delta),
+    merge: (ops) => merge(counter, ops),
+  };
+};
+
+module.exports = { create, init, update, merge, value, operations };

--- a/lib/crdt/counter/type.js
+++ b/lib/crdt/counter/type.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const COUNTER = 'counter';
+
+module.exports = {
+  COUNTER,
+};


### PR DESCRIPTION
# WIP

I would like to build at least one e2e flow with a fully integrated CRDT so that I can make the interface for our CRTD ready for integration.

Once we are aligned on the interface, I will add tests and *.d.ts

# Topics to align on

- How will we use CRDTs in the project?
    - How are we going to integrate CRDTs with the metachema? Will CRDTs be a part of metaschema and will we have all CRDTs state in the JSON object that corresponds to the schema?
        I guess they might be in the obj 

On the client side we have the following:
- JS object with CRDTS that corresponds to the schema (schema is aware of CRDTS and will have the CRDTS state in the JSON object)
- We make some changes on the client side.
- Those changes are applied to the local state.
- Diffs are send to the server/ peer eventually. (maybe batched diffs)
- Server/ peer applies the diffs to the persisted state.


What is the CRDT counter data structure in the object that correspond to the meteaschema description:
schema:
```js
{
    militaryVictories: {type: 'counter', sybType: 'delta-based'}
}
```
object:
Option1 - plain number
```js
{
    militaryVictories: 1
}
```
Option2 - crdt structure

```js
{
    militaryVictories: {
        type: 'counter'
        strategy: 'delta-based' (aka sybType)
        'id1': 2
        'id2': 4
    }
}
```
----

Usage
```js
  const counter = handlers[militaryVictories.type][militaryVictories.strategy];
  stateA.militaryVictories = counter.inc(2)(stateA.militaryVictories);
  stateB.militaryVictories = counter.inc()(stateB.militaryVictories); // 1 by default
```

# ToDo 

- [ ] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
