### PR TITLE
Add FSI implementation over IndexedDB

### DIFF
--- a/lib/fsi-idb.js
+++ b/lib/fsi-idb.js
@@ -2,7 +2,7 @@
 
 const { generateUUID } = require('metautil');
 
-const defaultOptions = {
+const dbConfig = {
   name: 'gs-fsi',
   version: 1,
   storeName: 'nodes',
@@ -27,11 +27,10 @@ const once = (req) => {
   return promise.finally(() => ac.abort());
 };
 
-const openDB = async (options = defaultOptions) => {
+const openDB = async () => {
   if (dbRequest) 
     return dbRequest.result ? dbRequest.result : await once(dbRequest);
-  const normalizedOptions = { ...defaultOptions, ...options };
-  const { name, version, storeName, indexName, rootNode } = normalizedOptions;
+  const { name, version, storeName, indexName, rootNode } = dbConfig;
   dbRequest = indexedDB.open(name, version);
   dbRequest.onupgradeneeded = (event) => {
     const db = event.target.result;
@@ -47,7 +46,7 @@ const defaultQuery = ({ nodeId, store }) => once(store.get(nodeId));
 
 const queryPath = async (dirPath, options = {}, query = defaultQuery) => {
   const { create = false, mode = 'readonly' } = options;
-  const { storeName, indexName, rootNode } = defaultOptions;
+  const { storeName, indexName, rootNode } = dbConfig;
   const db = await openDB();
   const tx = db.transaction(storeName, mode);
   const store = tx.objectStore(storeName);

--- a/lib/fsi-idb.js
+++ b/lib/fsi-idb.js
@@ -1,126 +1,124 @@
 'use strict';
 
-/* global indexedDB */
+const { generateUUID } = require('metautil');
 
-const DB_NAME = 'gs-fsi';
-const DB_VERSION = 1;
-const NODES = 'nodes';
-const IDX_NODE = 'idx_node';
-const ROOT_ID = 'root';
-const ROOT_NODE = {
-  id: ROOT_ID,
-  parentId: null,
-  name: '/',
-  type: 'folder',
-  content: null,
+const defaultOptions = {
+  name: 'gs-fsi',
+  version: 1,
+  storeName: 'nodes',
+  indexName: 'idx_node',
+  rootNode: {
+    id: 'root',
+    parentId: null,
+    name: '/',
+    type: 'folder',
+    content: null,
+  },
 };
 
-const once = (req) =>
-  new Promise((resolve, reject) => {
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
+let dbRequest = null;
 
-let db = null;
+const once = (req) => {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const ac = new AbortController();
+  const { signal } = ac;
+  req.addEventListener('success', (e) => resolve(e.target.result), { signal });
+  req.addEventListener('error', (e) => reject(e.target.error), { signal });
+  return promise.finally(() => ac.abort());
+};
 
-const openDB = async () => {
-  if (db) return db;
-  const req = indexedDB.open(DB_NAME, DB_VERSION);
-  req.onupgradeneeded = () => {
-    const db = req.result;
-    if (!db.objectStoreNames.contains(NODES)) {
-      const store = db.createObjectStore(NODES, { keyPath: 'id' });
-      store.createIndex(IDX_NODE, ['parentId', 'name'], {
-        unique: true,
-      });
-      store.add(ROOT_NODE);
-    }
+const openDB = async (options = defaultOptions) => {
+  if (dbRequest) 
+    return dbRequest.result ? dbRequest.result : await once(dbRequest);
+  const normalizedOptions = { ...defaultOptions, ...options };
+  const { name, version, storeName, indexName, rootNode } = normalizedOptions;
+  dbRequest = indexedDB.open(name, version);
+  dbRequest.onupgradeneeded = (event) => {
+    const db = event.target.result;
+    if (db.objectStoreNames.contains(storeName)) return;
+    const store = db.createObjectStore(storeName, { keyPath: 'id' });
+    store.createIndex(indexName, ['parentId', 'name'], { unique: true });
+    store.add(rootNode);
   };
-  db = await once(req);
-  return db;
+  return await once(dbRequest);
 };
 
-const resolveDir = async (dirPath, options = {}) => {
-  const { create = false, mode = 'readwrite' } = options;
-  const connection = await openDB();
-  const tx = connection.transaction(NODES, mode);
-  const store = tx.objectStore(NODES);
-  const index = store.index(IDX_NODE);
+const defaultQuery = ({ nodeId, store }) => once(store.get(nodeId));
+
+const queryPath = async (dirPath, options = {}, query = defaultQuery) => {
+  const { create = false, mode = 'readonly' } = options;
+  const { storeName, indexName, rootNode } = defaultOptions;
+  const db = await openDB();
+  const tx = db.transaction(storeName, mode);
+  const store = tx.objectStore(storeName);
+  const index = store.index(indexName);
   const parts = dirPath.split('/').filter(Boolean);
-  let currentId = ROOT_ID;
+  let currentNodeId = rootNode.id;
   for (const part of parts) {
-    const nodeId = await once(index.getKey([currentId, part]));
-    if (!nodeId && !create) {
-      throw new DOMException('Directory not found', 'NotFoundError');
-    }
+    const nodeId = await once(index.getKey([currentNodeId, part]));
     if (nodeId) {
-      currentId = nodeId;
-    } else {
-      currentId = await once(
-        store.add({
-          id: crypto.randomUUID(),
-          parentId: currentId,
-          name: part,
-          type: 'folder',
-          content: null,
-        }),
-      );
+      currentNodeId = nodeId;
+      continue;
     }
+    if (!create) 
+      throw new DOMException('Directory not found', 'NotFoundError');
+    const node = {
+      id: generateUUID(),
+      parentId: currentNodeId,
+      name: part,
+      type: 'folder',
+      content: null,
+    };
+    currentNodeId = await once(store.add(node));
   }
-  return {
-    getNode: () => once(store.get(currentId)),
-    readFile: (name) => once(index.get([currentId, name])),
-    async writeFile(name, content) {
-      const existing = await once(index.get([currentId, name]));
-      if (existing) {
-        existing.content = content;
-        return once(store.put(existing));
-      }
-      return once(
-        store.add({
-          id: crypto.randomUUID(),
-          parentId: currentId,
-          name,
-          type: 'file',
-          content,
-        }),
-      );
-    },
-    async removeFile(name) {
-      const nodeId = await once(index.getKey([currentId, name]));
-      if (nodeId) await once(store.delete(nodeId));
-    },
-  };
+  return await query({ nodeId: currentNodeId, store, index });
 };
 
-const read = async (dir, filename) => {
-  const folder = await resolveDir(dir);
-  const node = await folder.readFile(filename);
+const read = async (dirPath, filename) => {
+  const query = ({ nodeId, index }) => once(index.get([nodeId, filename]));
+  const node = await queryPath(dirPath, { mode: 'readonly' }, query);
   if (!node) throw new DOMException('File not found', 'NotFoundError');
   return node.content;
 };
 
-const write = async (dir, filename, content) => {
-  const folder = await resolveDir(dir, { create: true });
-  await folder.writeFile(filename, content);
+const write = async (dirPath, filename, content) => {
+  const query = async ({ nodeId, store, index }) => {
+    const node = await once(index.get([nodeId, filename]));
+    if (node) {
+      node.content = content;
+      return once(store.put(node));
+    }
+    const fileNode = {
+      id: generateUUID(),
+      parentId: nodeId,
+      name: filename,
+      type: 'file',
+      content,
+    };
+    return once(store.add(fileNode));
+  };
+  await queryPath(dirPath, { create: true, mode: 'readwrite' }, query);
 };
 
-const exists = async (dir, filename) => {
+const exists = async (dirPath, filename) => {
   try {
-    const folder = await resolveDir(dir);
-    const node = await folder.readFile(filename);
-    return node !== undefined;
+    const query = ({ nodeId, index }) => once(index.getKey([nodeId, filename]));
+    const nodeId = await queryPath(dirPath, { mode: 'readonly' }, query);
+    return nodeId !== undefined;
   } catch {
     return false;
   }
 };
 
-const remove = async (dir, filename) => {
+const remove = async (dirPath, filename) => {
   try {
-    const folder = await resolveDir(dir);
-    await folder.removeFile(filename);
+    const query = async ({ nodeId, store, index }) => {
+      const fileId = await once(index.getKey([nodeId, filename]));
+      if (fileId) await once(store.delete(fileId));
+    };
+    await queryPath(dirPath, { mode: 'readwrite' }, query);
   } catch {
-    // Directory not found — nothing to remove
+    return;
   }
 };
 

--- a/lib/fsi-idb.js
+++ b/lib/fsi-idb.js
@@ -1,0 +1,127 @@
+'use strict';
+
+/* global indexedDB */
+
+const DB_NAME = 'gs-fsi';
+const DB_VERSION = 1;
+const NODES = 'nodes';
+const IDX_NODE = 'idx_node';
+const ROOT_ID = 'root';
+const ROOT_NODE = {
+  id: ROOT_ID,
+  parentId: null,
+  name: '/',
+  type: 'folder',
+  content: null,
+};
+
+const once = (req) =>
+  new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+let db = null;
+
+const openDB = async () => {
+  if (db) return db;
+  const req = indexedDB.open(DB_NAME, DB_VERSION);
+  req.onupgradeneeded = () => {
+    const db = req.result;
+    if (!db.objectStoreNames.contains(NODES)) {
+      const store = db.createObjectStore(NODES, { keyPath: 'id' });
+      store.createIndex(IDX_NODE, ['parentId', 'name'], {
+        unique: true,
+      });
+      store.add(ROOT_NODE);
+    }
+  };
+  db = await once(req);
+  return db;
+};
+
+const resolveDir = async (dirPath, options = {}) => {
+  const { create = false, mode = 'readwrite' } = options;
+  const connection = await openDB();
+  const tx = connection.transaction(NODES, mode);
+  const store = tx.objectStore(NODES);
+  const index = store.index(IDX_NODE);
+  const parts = dirPath.split('/').filter(Boolean);
+  let currentId = ROOT_ID;
+  for (const part of parts) {
+    const nodeId = await once(index.getKey([currentId, part]));
+    if (!nodeId && !create) {
+      throw new DOMException('Directory not found', 'NotFoundError');
+    }
+    if (nodeId) {
+      currentId = nodeId;
+    } else {
+      currentId = await once(
+        store.add({
+          id: crypto.randomUUID(),
+          parentId: currentId,
+          name: part,
+          type: 'folder',
+          content: null,
+        }),
+      );
+    }
+  }
+  return {
+    getNode: () => once(store.get(currentId)),
+    readFile: (name) => once(index.get([currentId, name])),
+    async writeFile(name, content) {
+      const existing = await once(index.get([currentId, name]));
+      if (existing) {
+        existing.content = content;
+        return once(store.put(existing));
+      }
+      return once(
+        store.add({
+          id: crypto.randomUUID(),
+          parentId: currentId,
+          name,
+          type: 'file',
+          content,
+        }),
+      );
+    },
+    async removeFile(name) {
+      const nodeId = await once(index.getKey([currentId, name]));
+      if (nodeId) await once(store.delete(nodeId));
+    },
+  };
+};
+
+const read = async (dir, filename) => {
+  const folder = await resolveDir(dir);
+  const node = await folder.readFile(filename);
+  if (!node) throw new DOMException('File not found', 'NotFoundError');
+  return node.content;
+};
+
+const write = async (dir, filename, content) => {
+  const folder = await resolveDir(dir, { create: true });
+  await folder.writeFile(filename, content);
+};
+
+const exists = async (dir, filename) => {
+  try {
+    const folder = await resolveDir(dir);
+    const node = await folder.readFile(filename);
+    return node !== undefined;
+  } catch {
+    return false;
+  }
+};
+
+const remove = async (dir, filename) => {
+  try {
+    const folder = await resolveDir(dir);
+    await folder.removeFile(filename);
+  } catch {
+    // Directory not found — nothing to remove
+  }
+};
+
+module.exports = { read, write, exists, remove };

--- a/test/fsi-idb.js
+++ b/test/fsi-idb.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const test = require('node:test');
+const { installMockIdb } = require('./utils/mock-idb.js');
+const { runFsiTests } = require('./suites/fsi.js');
+
+test('fsi-idb module (IndexedDB mock)', async (t) => {
+  const idb = installMockIdb();
+  t.after(() => idb.uninstall());
+
+  const fsiIdb = require('../lib/fsi-idb.js');
+
+  await runFsiTests(t, fsiIdb, {
+    getRoot: async () =>
+      `idb-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+    joinPath: (root, ...parts) => [root, ...parts].join('/'),
+  });
+});

--- a/test/utils/mock-idb.js
+++ b/test/utils/mock-idb.js
@@ -7,7 +7,7 @@ const installMockIdb = () => {
     'indexedDB',
   );
 
-  class MockIDBRequest {
+  class MockIDBRequest extends EventTarget {
     result = undefined;
     error = null;
     onsuccess = null;
@@ -15,11 +15,13 @@ const installMockIdb = () => {
 
     _resolve(value) {
       this.result = value;
+      this.dispatchEvent(new Event('success'));
       if (this.onsuccess) this.onsuccess({ target: this });
     }
 
     _reject(err) {
       this.error = err;
+      this.dispatchEvent(new Event('error'));
       if (this.onerror) this.onerror({ target: this });
     }
   }
@@ -181,12 +183,12 @@ const installMockIdb = () => {
           databases.set(name, dbRecord);
         }
         const db = new MockIDBDatabase(dbRecord);
-        req.result = db;
         if (needsUpgrade) {
+          req.result = db;
           dbRecord.version = version;
           if (req.onupgradeneeded) req.onupgradeneeded({ target: req });
         }
-        if (req.onsuccess) req.onsuccess({ target: req });
+        req._resolve(db);
       });
       return req;
     },

--- a/test/utils/mock-idb.js
+++ b/test/utils/mock-idb.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const installMockIdb = () => {
+  const databases = new Map();
+  const prevIndexedDB = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'indexedDB',
+  );
+
+  class MockIDBRequest {
+    result = undefined;
+    error = null;
+    onsuccess = null;
+    onerror = null;
+
+    _resolve(value) {
+      this.result = value;
+      if (this.onsuccess) this.onsuccess({ target: this });
+    }
+
+    _reject(err) {
+      this.error = err;
+      if (this.onerror) this.onerror({ target: this });
+    }
+  }
+
+  class MockIDBIndex {
+    #data;
+    #keyPath;
+
+    constructor(data, keyPath) {
+      this.#data = data;
+      this.#keyPath = keyPath;
+    }
+
+    #match(record, searchKey) {
+      if (Array.isArray(this.#keyPath)) {
+        for (let i = 0; i < this.#keyPath.length; i++) {
+          if (record[this.#keyPath[i]] !== searchKey[i]) return false;
+        }
+        return true;
+      }
+      return record[this.#keyPath] === searchKey;
+    }
+
+    #find(searchKey) {
+      for (const [pk, record] of this.#data) {
+        if (this.#match(record, searchKey)) return { pk, record };
+      }
+      return null;
+    }
+
+    get(searchKey) {
+      const req = new MockIDBRequest();
+      const found = this.#find(searchKey);
+      queueMicrotask(() => req._resolve(found ? found.record : undefined));
+      return req;
+    }
+
+    getKey(searchKey) {
+      const req = new MockIDBRequest();
+      const found = this.#find(searchKey);
+      queueMicrotask(() => req._resolve(found ? found.pk : undefined));
+      return req;
+    }
+  }
+
+  class MockIDBObjectStore {
+    #data;
+    #keyPath;
+    #indexes;
+
+    constructor(data, keyPath, indexes) {
+      this.#data = data;
+      this.#keyPath = keyPath;
+      this.#indexes = indexes;
+    }
+
+    get(key) {
+      const req = new MockIDBRequest();
+      const value = this.#data.get(key);
+      queueMicrotask(() => req._resolve(value));
+      return req;
+    }
+
+    add(record) {
+      const req = new MockIDBRequest();
+      const key = record[this.#keyPath];
+      this.#data.set(key, record);
+      queueMicrotask(() => req._resolve(key));
+      return req;
+    }
+
+    put(record) {
+      const req = new MockIDBRequest();
+      const key = record[this.#keyPath];
+      this.#data.set(key, record);
+      queueMicrotask(() => req._resolve(key));
+      return req;
+    }
+
+    delete(key) {
+      const req = new MockIDBRequest();
+      this.#data.delete(key);
+      queueMicrotask(() => req._resolve(undefined));
+      return req;
+    }
+
+    createIndex(name, keyPath) {
+      this.#indexes.set(name, { keyPath });
+    }
+
+    index(name) {
+      const idx = this.#indexes.get(name);
+      if (!idx) throw new DOMException(`No index: ${name}`, 'NotFoundError');
+      return new MockIDBIndex(this.#data, idx.keyPath);
+    }
+  }
+
+  class MockIDBTransaction {
+    #stores;
+
+    constructor(stores) {
+      this.#stores = stores;
+    }
+
+    objectStore(name) {
+      const store = this.#stores.get(name);
+      if (!store) {
+        throw new DOMException(`No store: ${name}`, 'NotFoundError');
+      }
+      return new MockIDBObjectStore(store.data, store.keyPath, store.indexes);
+    }
+  }
+
+  class MockIDBDatabase {
+    #dbRecord;
+
+    constructor(dbRecord) {
+      this.#dbRecord = dbRecord;
+    }
+
+    get objectStoreNames() {
+      const names = [...this.#dbRecord.stores.keys()];
+      return { contains: (n) => names.includes(n) };
+    }
+
+    createObjectStore(name, options = {}) {
+      const storeRecord = {
+        keyPath: options.keyPath || null,
+        data: new Map(),
+        indexes: new Map(),
+      };
+      this.#dbRecord.stores.set(name, storeRecord);
+      return new MockIDBObjectStore(
+        storeRecord.data,
+        storeRecord.keyPath,
+        storeRecord.indexes,
+      );
+    }
+
+    transaction(storeNames) {
+      const stores = new Map();
+      const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+      for (const name of names) {
+        stores.set(name, this.#dbRecord.stores.get(name));
+      }
+      return new MockIDBTransaction(stores);
+    }
+  }
+
+  const mockIndexedDB = {
+    open(name, version) {
+      const req = new MockIDBRequest();
+      queueMicrotask(() => {
+        let dbRecord = databases.get(name);
+        const isNew = !dbRecord;
+        const needsUpgrade = isNew || dbRecord.version < version;
+        if (isNew) {
+          dbRecord = { version, stores: new Map() };
+          databases.set(name, dbRecord);
+        }
+        const db = new MockIDBDatabase(dbRecord);
+        req.result = db;
+        if (needsUpgrade) {
+          dbRecord.version = version;
+          if (req.onupgradeneeded) req.onupgradeneeded({ target: req });
+        }
+        if (req.onsuccess) req.onsuccess({ target: req });
+      });
+      return req;
+    },
+  };
+
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value: mockIndexedDB,
+  });
+
+  const reset = () => {
+    databases.clear();
+  };
+
+  const uninstall = () => {
+    if (prevIndexedDB) {
+      Object.defineProperty(globalThis, 'indexedDB', prevIndexedDB);
+    } else {
+      delete globalThis.indexedDB;
+    }
+  };
+
+  return { reset, uninstall };
+};
+
+module.exports = { installMockIdb };


### PR DESCRIPTION
## Summary

- Implement `lib/fsi-idb.js` — file system interface backed by IndexedDB with a tree-based node structure (folders and files in a single `nodes` object store, composite index on `[parentId, name]`)
- Add `test/utils/mock-idb.js` — in-memory IndexedDB mock for Node.js testing (follows `mock-opfs.js` pattern)
- Add `test/fsi-idb.js` — wires shared FSI test suite to the IDB implementation

## Test plan

- [x] All 4 shared FSI tests pass (`node --test test/fsi-idb.js`)
- [x] Full test suite passes (`npm test` — 93 tests, lint, types, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)